### PR TITLE
Update package names from @connectorkit to @connector-kit

### DIFF
--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_packages:
-        description: "Publish @connectorkit packages to npm"
+        description: "Publish @connector-kit packages to npm"
         type: boolean
         default: true
 
@@ -52,25 +52,25 @@ jobs:
       - name: Run tests (skip for now)
         run: echo "Skipping tests for initial publish"
 
-      - name: Publish @connectorkit/connector
+      - name: Publish @connector-kit/connector
         working-directory: packages/connector
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish @connectorkit/sdk
+      - name: Publish @connector-kit/sdk
         working-directory: packages/sdk
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish @connectorkit/jupiter
+      - name: Publish @connector-kit/jupiter
         working-directory: packages/jupiter
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish @connectorkit/providers
+      - name: Publish @connector-kit/providers
         working-directory: packages/providers
         run: npm publish --access public
         env:
@@ -95,23 +95,23 @@ jobs:
           body: |
             ## ConnectorKit Packages Published
 
-            ### @connectorkit/connector
-            - Package: `@connectorkit/connector`
+            ### @connector-kit/connector
+            - Package: `@connector-kit/connector`
             - Version: ${{ github.ref_name }}
             - Registry: npm
 
-            ### @connectorkit/sdk
-            - Package: `@connectorkit/sdk`
+            ### @connector-kit/sdk
+            - Package: `@connector-kit/sdk`
             - Version: ${{ github.ref_name }}
             - Registry: npm
 
-            ### @connectorkit/jupiter
-            - Package: `@connectorkit/jupiter`
+            ### @connector-kit/jupiter
+            - Package: `@connector-kit/jupiter`
             - Version: ${{ github.ref_name }}
             - Registry: npm
 
-            ### @connectorkit/providers
-            - Package: `@connectorkit/providers`
+            ### @connector-kit/providers
+            - Package: `@connector-kit/providers`
             - Version: ${{ github.ref_name }}
             - Registry: npm
 
@@ -119,22 +119,22 @@ jobs:
 
             **Install the main SDK:**
             ```bash
-            npm install @connectorkit/sdk@${{ github.ref_name }}
+            npm install @connector-kit/sdk@${{ github.ref_name }}
             ```
 
             **Install the connector (if using headless):**
             ```bash
-            npm install @connectorkit/connector@${{ github.ref_name }}
+            npm install @connector-kit/connector@${{ github.ref_name }}
             ```
 
             **Install Jupiter integration:**
             ```bash
-            npm install @connectorkit/jupiter@${{ github.ref_name }}
+            npm install @connector-kit/jupiter@${{ github.ref_name }}
             ```
 
             **Install providers:**
             ```bash
-            npm install @connectorkit/providers@${{ github.ref_name }}
+            npm install @connector-kit/providers@${{ github.ref_name }}
             ```
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -77,17 +77,17 @@ You can also trigger publishing manually:
 
 The following packages will be published to npm:
 
-- `@connectorkit/connector` - Headless wallet connector
-- `@connectorkit/sdk` - React hooks for Solana development
-- `@connectorkit/jupiter` - Jupiter integration
-- `@connectorkit/providers` - Providers package
+- `@connector-kit/connector` - Headless wallet connector
+- `@connector-kit/sdk` - React hooks for Solana development
+- `@connector-kit/jupiter` - Jupiter integration
+- `@connector-kit/providers` - Providers package
 
 ## Package Dependencies
 
 The packages have the following dependency structure:
-- `@connectorkit/sdk` depends on `@connectorkit/connector`
-- `@connectorkit/jupiter` depends on `@connectorkit/sdk`
-- `@connectorkit/providers` depends on both `@connectorkit/sdk` and `@connectorkit/jupiter`
+- `@connector-kit/sdk` depends on `@connector-kit/connector`
+- `@connector-kit/jupiter` depends on `@connector-kit/sdk`
+- `@connector-kit/providers` depends on both `@connector-kit/sdk` and `@connector-kit/jupiter`
 
 The workflow will publish them in the correct order to handle these dependencies.
 
@@ -127,16 +127,16 @@ Once published, users can install your packages:
 
 ```bash
 # Install the main SDK
-npm install @connectorkit/sdk
+npm install @connector-kit/sdk
 
 # Install the connector for headless usage
-npm install @connectorkit/connector
+npm install @connector-kit/connector
 
 # Install Jupiter integration
-npm install @connectorkit/jupiter
+npm install @connector-kit/jupiter
 
 # Install providers
-npm install @connectorkit/providers
+npm install @connector-kit/providers
 ```
 
 The packages are designed to work together as a complete Solana development toolkit.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,8 +9,8 @@
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {
-    "@connectorkit/jupiter": "workspace:*",
-    "@connectorkit/sdk": "workspace:*",
+    "@connector-kit/jupiter": "workspace:*",
+    "@connector-kit/sdk": "workspace:*",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-avatar": "^1.1.10",

--- a/packages/connector/package.json
+++ b/packages/connector/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@connectorkit/connector",
+  "name": "@connector-kit/connector",
   "version": "0.0.0",
   "description": "Headless wallet connector client and React provider built on Wallet Standard",
   "main": "./dist/index.js",

--- a/packages/connector/tsup.config.ts
+++ b/packages/connector/tsup.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   treeshake: true,
   minify: process.env.NODE_ENV === 'production',
   splitting: true,
-  external: ['react', 'react-dom', '@connectorkit/sdk'],
+  external: ['react', 'react-dom', '@connector-kit/sdk'],
   esbuildOptions: (options) => {
     // React 19 optimizations
     options.treeShaking = true

--- a/packages/jupiter/package.json
+++ b/packages/jupiter/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@connectorkit/jupiter",
+  "name": "@connector-kit/jupiter",
   "version": "0.0.1",
   "private": false,
   "type": "module",
@@ -19,10 +19,10 @@
     "lint": "echo skip"
   },
   "peerDependencies": {
-    "@connectorkit/sdk": "*"
+    "@connector-kit/sdk": "*"
   },
   "devDependencies": {
-    "@connectorkit/sdk": "workspace:*",
+    "@connector-kit/sdk": "workspace:*",
     "@solana/kit": "^2.0.0",
     "tsup": "^8.5.0",
     "typescript": "^5.3.3"

--- a/packages/jupiter/src/index.ts
+++ b/packages/jupiter/src/index.ts
@@ -1,4 +1,4 @@
-import type { SwapProvider, SwapParams, SwapQuote, SwapBuild } from '@connectorkit/sdk'
+import type { SwapProvider, SwapParams, SwapQuote, SwapBuild } from '@connector-kit/sdk'
 
 export interface JupiterQuoteResponse {
   outAmount: string

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@connectorkit/providers",
+  "name": "@connector-kit/providers",
   "version": "0.0.1",
   "private": false,
   "type": "module",
@@ -19,13 +19,13 @@
     "lint": "echo skip"
   },
   "peerDependencies": {
-    "@connectorkit/sdk": "*"
+    "@connector-kit/sdk": "*"
   },
   "dependencies": {
-    "@connectorkit/jupiter": "workspace:*"
+    "@connector-kit/jupiter": "workspace:*"
   },
   "devDependencies": {
-    "@connectorkit/sdk": "workspace:*",
+    "@connector-kit/sdk": "workspace:*",
     "tsup": "^8.5.0",
     "typescript": "^5.3.3"
   },

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -8,7 +8,7 @@ export {
   type JupiterQuoteResponse,
   type JupiterSwapResponse,
   getJupiterTokens 
-} from '@connectorkit/jupiter'
+} from '@connector-kit/jupiter'
 
 // Future providers will be added here:
 // export { createKamino, type KaminoConfig } from '@connectorkit/kamino'
@@ -16,7 +16,7 @@ export {
 // export { createOrcaWhirlpools, type OrcaConfig } from '@connectorkit/orca'
 
 // Import locally for internal use
-import { createJupiter } from '@connectorkit/jupiter'
+import { createJupiter } from '@connector-kit/jupiter'
 
 // Provider registry type for future extensibility
 export interface ProviderRegistry {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@connectorkit/sdk",
+  "name": "@connector-kit/sdk",
   "version": "0.0.0",
   "description": "React hooks for Solana development - MVP with essential hooks only",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
     "@tanstack/react-query": { "optional": true }
   },
   "dependencies": {
-    "@connectorkit/connector": "workspace:*",
+    "@connector-kit/connector": "workspace:*",
     "@solana-program/compute-budget": "^0.3.0",
     "@solana-program/system": "^0.7.0",
     "@solana-program/token": "^0.5.1",

--- a/packages/sdk/src/core/arc-provider.tsx
+++ b/packages/sdk/src/core/arc-provider.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import type { ReactNode } from 'react'
 import { ArcClientProvider, useArcClient } from './arc-client-provider'
-import { useConnectorClient } from '@connectorkit/connector'
+import { useConnectorClient } from '@connector-kit/connector'
 import type { ArcWebClientConfig } from './arc-web-client'
 import type { SolanaConfig } from '../config/create-config'
 import type { QueryClient } from '@tanstack/react-query'

--- a/packages/sdk/src/core/arc-web-client.ts
+++ b/packages/sdk/src/core/arc-web-client.ts
@@ -9,7 +9,7 @@ import {
   WalletStandardKitSigner,
   type StandardWalletInfo,
 } from '../hooks/use-standard-wallets'
-import { type ConnectorState, ConnectorClient } from '@connectorkit/connector'
+import { type ConnectorState, ConnectorClient } from '@connector-kit/connector'
 import type { SolanaCluster } from '@wallet-ui/core'
 
 // Connector is the single source of truth; no Arc-managed persistence

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -7,7 +7,7 @@
     "noEmit": false,
     "baseUrl": ".",
     "paths": {
-      "@connectorkit/connector": ["./src/types/connector-kit-shim.d.ts"]
+      "@connector-kit/connector": ["./src/types/connector-kit-shim.d.ts"]
     }
   },
   "include": ["src/**/*"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,10 +45,10 @@ importers:
 
   apps/docs:
     dependencies:
-      '@connectorkit/jupiter':
+      '@connector-kit/jupiter':
         specifier: workspace:*
         version: link:../../packages/jupiter
-      '@connectorkit/sdk':
+      '@connector-kit/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
       '@radix-ui/react-accordion':
@@ -248,7 +248,7 @@ importers:
 
   packages/jupiter:
     devDependencies:
-      '@connectorkit/sdk':
+      '@connector-kit/sdk':
         specifier: workspace:*
         version: link:../sdk
       '@solana/kit':
@@ -263,11 +263,11 @@ importers:
 
   packages/providers:
     dependencies:
-      '@connectorkit/jupiter':
+      '@connector-kit/jupiter':
         specifier: workspace:*
         version: link:../jupiter
     devDependencies:
-      '@connectorkit/sdk':
+      '@connector-kit/sdk':
         specifier: workspace:*
         version: link:../sdk
       tsup:
@@ -279,7 +279,7 @@ importers:
 
   packages/sdk:
     dependencies:
-      '@connectorkit/connector':
+      '@connector-kit/connector':
         specifier: workspace:*
         version: link:../connector
       '@nanostores/react':


### PR DESCRIPTION
- Rename all packages to use @connector-kit scope
- Update internal dependencies and imports
- Fix TypeScript paths and external references
- Update workflow files and documentation
- All packages now build successfully

This matches the existing npm organization: @connector-kit