### PR TITLE
Fix formatting in README title for connector

### DIFF
--- a/packages/connector/README.md
+++ b/packages/connector/README.md
@@ -1,5 +1,5 @@
 ---
-title: @solana/connector
+title: "@solana/connector"
 description: Production-ready wallet connector for Solana applications
 ---
 


### PR DESCRIPTION
## Summary

This PR fixes a YAML front matter parsing error caused by an unquoted `title` value that begins with `@` (e.g. `@solana/connector`). Some YAML parsers treat `@` as an invalid token start when scanning plain scalars, which results in:

> `Error in user YAML: found character that cannot start any token at line 1 column 8`

To improve compatibility across parsers, the `title` (and optionally other front matter string values) is now quoted.

## Changes

- Quote the `title` value in the Markdown front matter:
  - `title: @solana/connector` → `title: "@solana/connector"`
- (Optional) Quote other front matter string values for consistency and cross-parser compatibility.

## Why

- `@` at the beginning of an unquoted YAML scalar can fail in stricter/older YAML implementations.
- Quoting front matter strings makes the docs build/render reliably across different tooling (static site generators, doc platforms, CI pipelines).

## Before / After

**Before**
```yaml
---
title: @solana/connector
description: Production-ready wallet connector for Solana applications
---
