### PR TITLE
ci: bump publish workflow to Node 22 for npm@12 compatibility

### DIFF
--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # npm@latest (v12+) requires Node ^22.22.2 || ^24.15.0 || >=26
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm


### PR DESCRIPTION
## Problem
The `Publish SDKs` workflow fails at the "Update npm for trusted publishing" step:

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

`npm install -g npm@latest` now resolves to npm@12, which dropped Node 20 support — but the workflow pins `node-version: '20'`.

## Fix
Bump the publish job to Node 22. This satisfies npm@12's engines while staying within the repo's `engines.node >=20.18.0` range. CI (`ci.yml`) already runs on `lts/*`, and both packages build/test green on modern Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)