### PR TITLE
ci: use latest LTS Node with bundled npm for trusted publishing

### DIFF
--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -33,21 +33,18 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          # npm@latest (v12+) requires Node ^22.22.2 || ^24.15.0 || >=26
-          node-version: '22'
+          # Latest LTS (Node 24+) bundles npm >=11.6, which supports trusted
+          # publishing (needs npm >=11.5.1) out of the box — no manual npm
+          # upgrade needed. Deliberately NOT running `npm install -g npm@latest`:
+          # npm@12.0.0 has a packaging bug (libnpmpublish requires `sigstore`
+          # but npm@12 doesn't bundle it) that breaks provenance publishes.
+          node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 10.28.0
-
-      - name: Update npm for trusted publishing
-        # Trusted publishing needs npm >=11.5.1. Pinned to 11 because npm@12.0.0
-        # has a packaging bug: libnpmpublish@12 requires `sigstore` but npm@12
-        # doesn't bundle it, so `npm publish` with provenance crashes with
-        # MODULE_NOT_FOUND. Revisit when npm@12.x fixes the sigstore bundling.
-        run: npm install -g npm@11
+          version: 11
 
       - name: Setup pnpm cache
         uses: actions/cache@v4

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -43,7 +43,11 @@ jobs:
           version: 10.28.0
 
       - name: Update npm for trusted publishing
-        run: npm install -g npm@latest
+        # Trusted publishing needs npm >=11.5.1. Pinned to 11 because npm@12.0.0
+        # has a packaging bug: libnpmpublish@12 requires `sigstore` but npm@12
+        # doesn't bundle it, so `npm publish` with provenance crashes with
+        # MODULE_NOT_FOUND. Revisit when npm@12.x fixes the sigstore bundling.
+        run: npm install -g npm@11
 
       - name: Setup pnpm cache
         uses: actions/cache@v4


### PR DESCRIPTION
## Problem
Two consecutive publish failures, both caused by the `npm install -g npm@latest` step:
1. `EBADENGINE` — npm@12 dropped Node 20 (fixed by #53's Node 22 bump)
2. `MODULE_NOT_FOUND: sigstore` — npm@12.0.0 has a packaging bug: `libnpmpublish@12` requires `sigstore` for provenance signing, but npm@12's bundle omits it. Trusted publishing (`id-token: write`) always takes the provenance path → every publish crashes.

There is no fixed npm 12.x yet (`latest` = 12.0.0), and even Node's main branch still bundles npm **11.18.0**.

## Fix — latest everything, no self-upgrade
- `node-version: 'lts/*'` → Node 24 LTS, whose **bundled npm (≥11.6) already supports trusted publishing** (needs ≥11.5.1)
- **Delete the npm self-upgrade step** — nothing to pin, nothing to break; when Node LTS rolls in a fixed npm 12, we inherit it automatically
- `pnpm/action-setup@v4` with pnpm 11, matching the lockfile (written by pnpm 11.2.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)