### PR TITLE
ci: let pnpm/action-setup read version from packageManager field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9.12.3
+        # No explicit version: action-setup v4 reads the `packageManager`
+        # field from package.json (single source of truth).
+        uses: pnpm/action-setup@v4
 
       - name: Setup pnpm cache
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,24 +22,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Setup pnpm
+        # No explicit version: action-setup v4 reads the `packageManager`
+        # field from package.json (single source of truth). Must run before
+        # setup-node so its `cache: pnpm` can resolve the real store path.
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Setup pnpm
-        # No explicit version: action-setup v4 reads the `packageManager`
-        # field from package.json (single source of truth).
-        uses: pnpm/action-setup@v4
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+          # Built-in pnpm caching resolves the store path via `pnpm store path`
+          # (~/.local/share/pnpm/store on Linux) — a hardcoded ~/.pnpm-store
+          # path never matched, so the old manual cache never hit.
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -30,6 +30,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Setup pnpm
+        # No explicit version: action-setup v4 reads the `packageManager`
+        # field from package.json (single source of truth) and errors if
+        # a version is also specified here. Must run before setup-node so
+        # its `cache: pnpm` can resolve the real store path.
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -40,20 +47,10 @@ jobs:
           # but npm@12 doesn't bundle it) that breaks provenance publishes.
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Setup pnpm
-        # No explicit version: action-setup v4 reads the `packageManager`
-        # field from package.json (single source of truth) and errors if
-        # a version is also specified here.
-        uses: pnpm/action-setup@v4
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+          # Built-in pnpm caching resolves the store path via `pnpm store path`
+          # (~/.local/share/pnpm/store on Linux) — a hardcoded ~/.pnpm-store
+          # path never matched, so the old manual cache never hit.
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -42,9 +42,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
+        # No explicit version: action-setup v4 reads the `packageManager`
+        # field from package.json (single source of truth) and errors if
+        # a version is also specified here.
         uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - name: Setup pnpm cache
         uses: actions/cache@v4


### PR DESCRIPTION
## Problem
The publish run after #54 failed at pnpm setup:

```
Error: Multiple versions of pnpm specified:
  - version 11 in the GitHub Action config with the key "version"
  - version pnpm@11.2.2 in the package.json with the key "packageManager"
```

`pnpm/action-setup@v4` refuses to proceed when both the action's `version` input and package.json's `packageManager` field define a version — by design, to prevent `ERR_PNPM_BAD_PM_VERSION` drift.

## Fix
Drop the explicit `version` from both workflows and let `packageManager: "pnpm@11.2.2"` be the single source of truth:
- **publish-sdks.yml** — remove `version: 11`
- **ci.yml** — migrate `action-setup@v2` + pnpm `9.12.3` (pre-dates the pnpm-11 lockfile) to `@v4` with no version

Now CI, publish, and local dev all resolve pnpm from the same field, and future pnpm bumps are a one-line package.json change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)