### PR TITLE
fix(connector): address OCMS review findings (stacked on #51)

### DIFF
--- a/connectorkit/references/api.md
+++ b/connectorkit/references/api.md
@@ -151,6 +151,25 @@ const { signer, ready } = useKitTransactionSigner();
 // signer is TransactionModifyingSigner — compatible with @solana/kit pipelines
 ```
 
+### useSignOffchainMessage()
+
+Sign v1 off-chain messages (sRFC 38) via the `solana:signOffchainMessage` wallet feature.
+
+```ts
+const {
+    signOffchainMessage, // (message: string, options?) => Promise<SignedOffchainMessage>
+    canSignOffchainMessage, // connected wallet supports v1 off-chain messages
+    supportedMessageVersions, // readonly number[]
+    ready, // a wallet is connected and a signer is available
+    address, // string | null
+} = useSignOffchainMessage();
+
+const { signature, signedOffchainMessage, envelope } = await signOffchainMessage('Sign in');
+// Rejects with FEATURE_NOT_SUPPORTED (wallet lacks the feature), USER_REJECTED
+// (user cancelled), or SIGNING_FAILED (compile/sign/verify failure).
+// Headless equivalent: createOffchainMessageSigner({ wallet, account }) from '@solana/connector/headless'
+```
+
 ### useTransactionPreparer()
 
 Add blockhash + compute units to a transaction message.

--- a/examples/next-js/app/providers.tsx
+++ b/examples/next-js/app/providers.tsx
@@ -18,9 +18,16 @@ const getOrigin = () => {
 // For testing, default to true if not explicitly set to 'false'
 const ENABLE_REMOTE_SIGNER = process.env.NEXT_PUBLIC_ENABLE_REMOTE_SIGNER !== 'false';
 
+// The burner wallet keeps its throwaway key in plaintext localStorage and can sign on
+// mainnet, so it stays out of production connect modals unless a deployment opts in.
+const ENABLE_BURNER_WALLET =
+    process.env.NODE_ENV === 'development' || process.env.NEXT_PUBLIC_ENABLE_BURNER_WALLET === 'true';
+
 export function Providers({ children }: { children: ReactNode }) {
     useEffect(() => {
-        registerBurnerWallet();
+        if (ENABLE_BURNER_WALLET) {
+            registerBurnerWallet();
+        }
     }, []);
 
     const connectorConfig = useMemo(() => {

--- a/examples/next-js/components/playground/transactions-section.tsx
+++ b/examples/next-js/components/playground/transactions-section.tsx
@@ -472,9 +472,9 @@ function KitSignerDemo() {
 function OffchainMessageDemo() {
     const {
         signOffchainMessage,     // (message, options?) => Promise<SignedOffchainMessage>
-        canSignOffchainMessage,  // wallet advertises the feature with v1 support
+        canSignOffchainMessage,  // connected wallet advertises the feature with v1 support
         supportedMessageVersions,
-        ready,
+        ready,                   // a wallet is connected and a signer is available
     } = useSignOffchainMessage();
 
     async function handleSign(message: string) {
@@ -487,12 +487,16 @@ function OffchainMessageDemo() {
         return { signature, signedOffchainMessage };
     }
 
+    if (!ready) {
+        return <p>Connect a wallet first</p>;
+    }
+
     if (!canSignOffchainMessage) {
         return <p>Wallet does not support off-chain message signing</p>;
     }
 
     return (
-        <button onClick={() => handleSign('Sign in to Example App')} disabled={!ready}>
+        <button onClick={() => handleSign('Sign in to Example App')}>
             Sign Off-Chain Message
         </button>
     );

--- a/examples/next-js/components/transactions/offchain-message-demo.tsx
+++ b/examples/next-js/components/transactions/offchain-message-demo.tsx
@@ -44,7 +44,9 @@ export function OffchainMessageDemo() {
                 </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-                {!canSignOffchainMessage ? (
+                {!ready ? (
+                    <Alert>Connect a wallet to sign off-chain messages</Alert>
+                ) : !canSignOffchainMessage ? (
                     <Alert>Connected wallet does not support off-chain message signing</Alert>
                 ) : (
                     <>
@@ -61,7 +63,7 @@ export function OffchainMessageDemo() {
                             />
                             <Button
                                 onClick={handleSign}
-                                disabled={!ready || isSigning || !message.trim()}
+                                disabled={isSigning || !message.trim()}
                                 size="sm"
                                 className="w-full"
                             >

--- a/examples/next-js/components/transactions/transaction-demo.tsx
+++ b/examples/next-js/components/transactions/transaction-demo.tsx
@@ -7,7 +7,6 @@ import { LegacySolTransfer } from './legacy-sol-transfer';
 import { ModernSolTransfer } from './modern-sol-transfer';
 import { KitSignerDemo } from './kit-signer-demo';
 import { ChainUtilitiesDemo } from './chain-utilities-demo';
-import { OffchainMessageDemo } from './offchain-message-demo';
 import { ConnectionAbstractionDemo } from './connection-abstraction-demo';
 
 export function TransactionDemo() {
@@ -38,8 +37,6 @@ export function TransactionDemo() {
                 <KitSignerDemo />
                 <ChainUtilitiesDemo />
             </div>
-
-            <OffchainMessageDemo />
 
             <ConnectionAbstractionDemo />
         </div>

--- a/examples/next-js/lib/burner-wallet.ts
+++ b/examples/next-js/lib/burner-wallet.ts
@@ -33,14 +33,7 @@ const STORAGE_KEY = 'connectorkit-playground:burner-secret';
 
 const CHAINS: IdentifierArray = ['solana:mainnet', 'solana:devnet', 'solana:testnet'];
 
-const FEATURES: IdentifierArray = [
-    StandardConnect,
-    StandardDisconnect,
-    StandardEvents,
-    SolanaSignTransaction,
-    SolanaSignMessage,
-    SolanaSignOffchainMessage,
-];
+const ACCOUNT_FEATURES: IdentifierArray = [SolanaSignTransaction, SolanaSignMessage, SolanaSignOffchainMessage];
 
 const ICON: WalletIcon = `data:image/svg+xml;base64,${btoa(
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="8" fill="#f97316"/><path d="M16 6c2.5 4.2 6 5.9 6 10a6 6 0 1 1-12 0c0-4.1 3.5-5.8 6-10Z" fill="#fff7ed"/></svg>',
@@ -53,30 +46,35 @@ const ICON: WalletIcon = `data:image/svg+xml;base64,${btoa(
  * without a compatible browser extension, and it must never hold anything of value.
  */
 function loadOrCreateSeed(): Uint8Array {
-    const stored = window.localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-        try {
+    try {
+        const stored = window.localStorage.getItem(STORAGE_KEY);
+        if (stored) {
             const bytes = Uint8Array.from(JSON.parse(stored) as number[]);
             if (bytes.length === 32) {
                 return bytes;
             }
-        } catch {
-            // Fall through and mint a replacement for the unreadable entry.
         }
+    } catch {
+        // Storage may be unavailable (private browsing, partitioned iframes) or the
+        // entry unreadable; fall through and mint a seed, persisting it if we can.
     }
     const seed = crypto.getRandomValues(new Uint8Array(32));
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(seed)));
+    try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(seed)));
+    } catch {
+        // Ephemeral seed: the burner still works for this page load.
+    }
     return seed;
 }
 
 function loadKeyPair(): Promise<CryptoKeyPair> {
-    return createKeyPairFromPrivateKeyBytes(loadOrCreateSeed(), true);
+    return createKeyPairFromPrivateKeyBytes(loadOrCreateSeed());
 }
 
 class BurnerWalletAccount implements WalletAccount {
     readonly address: string;
     readonly chains = CHAINS;
-    readonly features = FEATURES;
+    readonly features = ACCOUNT_FEATURES;
     readonly label = 'Burner account';
     readonly publicKey: Uint8Array;
 
@@ -106,25 +104,6 @@ class BurnerWallet implements Wallet {
 
     get accounts(): readonly WalletAccount[] {
         return this.#account ? [this.#account] : [];
-    }
-
-    get features() {
-        return {
-            [SolanaSignMessage]: { signMessage: this.#signMessage, version: '1.0.0' as const },
-            [SolanaSignOffchainMessage]: {
-                signOffchainMessage: this.#signOffchainMessage,
-                supportedMessageVersions: [1] as const,
-                version: '1.0.0' as const,
-            },
-            [SolanaSignTransaction]: {
-                signTransaction: this.#signTransaction,
-                supportedTransactionVersions: ['legacy', 0] as const,
-                version: '1.0.0' as const,
-            },
-            [StandardConnect]: { connect: this.#connect, version: '1.0.0' as const },
-            [StandardDisconnect]: { disconnect: this.#disconnect, version: '1.0.0' as const },
-            [StandardEvents]: { on: this.#on, version: '1.0.0' as const },
-        };
     }
 
     #emitChange() {
@@ -197,20 +176,50 @@ class BurnerWallet implements Wallet {
         ...inputs: readonly SolanaSignOffchainMessageInput[]
     ): Promise<readonly SolanaSignOffchainMessageOutput[]> => {
         const keyPair = this.#requireKeyPair();
+        const ownAddress = this.#account?.address;
+        if (!ownAddress) {
+            throw new Error('Burner wallet is not connected');
+        }
         const addressDecoder = getAddressDecoder();
         return await Promise.all(
-            inputs.map(async ({ message, requiredSigners }) => {
+            inputs.map(async ({ message, messageVersion, requiredSigners }) => {
+                if (messageVersion !== 1) {
+                    throw new Error(`Unsupported off-chain message version: ${messageVersion}`);
+                }
+                const requiredSignatories = requiredSigners.map(publicKey => ({
+                    address: addressDecoder.decode(publicKey),
+                }));
+                if (!requiredSignatories.some(({ address }) => address === ownAddress)) {
+                    throw new Error('requiredSigners must include the signing account');
+                }
                 const envelope = compileOffchainMessageV1Envelope({
                     content: message,
-                    requiredSignatories: requiredSigners.map(publicKey => ({
-                        address: addressDecoder.decode(publicKey),
-                    })),
+                    requiredSignatories,
                     version: 1,
                 });
                 const signature = new Uint8Array(await signBytes(keyPair.privateKey, envelope.content));
                 return { signedOffchainMessage: envelope.content, signature };
             }),
         );
+    };
+
+    // Declared after the handlers above so class-field initialization order holds.
+    // A stable object (rather than a getter) keeps `wallet.features` identity-comparable.
+    readonly features = {
+        [SolanaSignMessage]: { signMessage: this.#signMessage, version: '1.0.0' as const },
+        [SolanaSignOffchainMessage]: {
+            signOffchainMessage: this.#signOffchainMessage,
+            supportedMessageVersions: [1] as const,
+            version: '1.0.0' as const,
+        },
+        [SolanaSignTransaction]: {
+            signTransaction: this.#signTransaction,
+            supportedTransactionVersions: ['legacy', 0] as const,
+            version: '1.0.0' as const,
+        },
+        [StandardConnect]: { connect: this.#connect, version: '1.0.0' as const },
+        [StandardDisconnect]: { disconnect: this.#disconnect, version: '1.0.0' as const },
+        [StandardEvents]: { on: this.#on, version: '1.0.0' as const },
     };
 }
 
@@ -231,5 +240,12 @@ export function registerBurnerWallet(): void {
 
 /** Forgets the persisted burner key, so the next connection mints a new one. */
 export function resetBurnerWallet(): void {
-    window.localStorage.removeItem(STORAGE_KEY);
+    if (typeof window === 'undefined') {
+        return;
+    }
+    try {
+        window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+        // Storage unavailable; nothing to forget.
+    }
 }

--- a/examples/next-js/package.json
+++ b/examples/next-js/package.json
@@ -24,7 +24,6 @@
         "@solana/connector": "workspace:*",
         "@solana/connector-debugger": "workspace:*",
         "@solana/keychain": "^1.4.0",
-        "@solana/codecs": "^7.0.0",
         "@solana/kit": "^7.0.0",
         "@solana/wallet-standard-features": "^1.4.0",
         "@solana/web3.js": "^1.98.4",

--- a/packages/connector/README.md
+++ b/packages/connector/README.md
@@ -712,7 +712,9 @@ import { useSignOffchainMessage } from '@solana/connector/react';
 function SignInButton() {
     const { signOffchainMessage, canSignOffchainMessage, ready } = useSignOffchainMessage();
 
-    if (!canSignOffchainMessage) return null;
+    // `ready` is true once a wallet is connected; `canSignOffchainMessage`
+    // additionally requires the wallet to support v1 off-chain messages.
+    if (!ready || !canSignOffchainMessage) return null;
 
     const handleSignIn = async () => {
         const { signature, signedOffchainMessage, envelope } = await signOffchainMessage(
@@ -723,7 +725,7 @@ function SignInButton() {
         // envelope: verified @solana/kit OffchainMessageEnvelope
     };
 
-    return <button onClick={handleSignIn} disabled={!ready}>Sign In</button>;
+    return <button onClick={handleSignIn}>Sign In</button>;
 }
 ```
 

--- a/packages/connector/src/hooks/use-sign-offchain-message.ts
+++ b/packages/connector/src/hooks/use-sign-offchain-message.ts
@@ -34,7 +34,8 @@ export interface UseSignOffchainMessageReturn {
     supportedMessageVersions: readonly number[];
 
     /**
-     * Whether off-chain message signing is available and ready to use
+     * Whether a wallet is connected and a signer is available.
+     * Check `canSignOffchainMessage` to know if that wallet supports the feature.
      */
     ready: boolean;
 
@@ -74,7 +75,7 @@ export function useSignOffchainMessage(): UseSignOffchainMessageReturn {
         signOffchainMessage,
         canSignOffchainMessage: signer?.canSignOffchainMessage ?? false,
         supportedMessageVersions: signer?.supportedMessageVersions ?? NO_SUPPORTED_MESSAGE_VERSIONS,
-        ready: Boolean(signer?.canSignOffchainMessage),
+        ready: Boolean(signer),
         address: selectedAccount,
     };
 }

--- a/packages/connector/src/lib/offchain-message/offchain-message-signer.test.ts
+++ b/packages/connector/src/lib/offchain-message/offchain-message-signer.test.ts
@@ -129,7 +129,28 @@ describe('createOffchainMessageSigner', () => {
         const { keyPair: otherKeyPair } = await createKeyedAccount();
         const signer = createOffchainMessageSigner({ wallet: createOffchainMessageWallet(otherKeyPair), account })!;
 
-        await expect(signer.signOffchainMessage('hello')).rejects.toThrow();
+        await expect(signer.signOffchainMessage('hello')).rejects.toMatchObject({ code: 'SIGNING_FAILED' });
+    });
+
+    it('rejects a message the codec cannot compile with the documented error code', async () => {
+        const { keyPair, account } = await createKeyedAccount();
+        const signer = createOffchainMessageSigner({ wallet: createOffchainMessageWallet(keyPair), account })!;
+
+        await expect(signer.signOffchainMessage('')).rejects.toMatchObject({ code: 'SIGNING_FAILED' });
+    });
+
+    it('classifies wallet cancellation as a recoverable USER_REJECTED error', async () => {
+        const { keyPair, account } = await createKeyedAccount();
+        const wallet = createOffchainMessageWallet(keyPair);
+        (wallet.features as Record<string, { signOffchainMessage: ReturnType<typeof vi.fn> }>)[
+            SolanaSignOffchainMessage
+        ].signOffchainMessage.mockRejectedValueOnce(new Error('User rejected the request.'));
+        const signer = createOffchainMessageSigner({ wallet, account })!;
+
+        await expect(signer.signOffchainMessage('hello')).rejects.toMatchObject({
+            code: 'USER_REJECTED',
+            recoverable: true,
+        });
     });
 
     it('rejects an already-aborted request before contacting the wallet', async () => {

--- a/packages/connector/src/lib/offchain-message/offchain-message-signer.ts
+++ b/packages/connector/src/lib/offchain-message/offchain-message-signer.ts
@@ -21,9 +21,21 @@ import type { Wallet, WalletAccount } from '@wallet-standard/base';
 
 import { SolanaSignOffchainMessage, type SolanaSignOffchainMessageFeature } from '@solana/wallet-standard-features';
 
-import { Errors, TransactionError } from '../errors';
+import { Errors, TransactionError, isConnectorError } from '../errors';
 
 type OffchainMessageFeature = SolanaSignOffchainMessageFeature[typeof SolanaSignOffchainMessage];
+
+/** Normalizes wallet-thrown errors so user cancellation surfaces as a recoverable USER_REJECTED. */
+function toOffchainMessageSigningError(error: unknown): Error {
+    if (isConnectorError(error)) {
+        return error;
+    }
+    const message = error instanceof Error ? error.message.toLowerCase() : '';
+    if (message.includes('user rejected') || message.includes('user denied')) {
+        return Errors.userRejected('off-chain message signing');
+    }
+    return new TransactionError('SIGNING_FAILED', 'Failed to sign off-chain message', undefined, error as Error);
+}
 
 /** Configuration for creating an off-chain message signer. */
 export interface OffchainMessageSignerConfig {
@@ -71,7 +83,7 @@ export function createOffchainMessageSigner(config: OffchainMessageSignerConfig)
     const feature = (wallet.features as Record<string, unknown>)[SolanaSignOffchainMessage] as
         OffchainMessageFeature | undefined;
     const signerAddress = account.address as Address;
-    const supportsV1 = feature?.supportedMessageVersions.includes(1) ?? false;
+    const supportsV1 = feature?.supportedMessageVersions?.includes(1) ?? false;
 
     return {
         address: account.address,
@@ -87,11 +99,21 @@ export function createOffchainMessageSigner(config: OffchainMessageSignerConfig)
                 throw Errors.featureNotSupported('off-chain message signing');
             }
 
-            const envelope = compileOffchainMessageV1Envelope({
-                version: 1,
-                content: message,
-                requiredSignatories: [{ address: signerAddress }],
-            });
+            let envelope: OffchainMessageEnvelope;
+            try {
+                envelope = compileOffchainMessageV1Envelope({
+                    version: 1,
+                    content: message,
+                    requiredSignatories: [{ address: signerAddress }],
+                });
+            } catch (error) {
+                throw new TransactionError(
+                    'SIGNING_FAILED',
+                    'Failed to compile off-chain message',
+                    undefined,
+                    error as Error,
+                );
+            }
 
             let output;
             try {
@@ -102,15 +124,8 @@ export function createOffchainMessageSigner(config: OffchainMessageSignerConfig)
                     requiredSigners: [account.publicKey],
                 });
             } catch (error) {
-                throw new TransactionError(
-                    'SIGNING_FAILED',
-                    'Failed to sign off-chain message',
-                    undefined,
-                    error as Error,
-                );
+                throw toOffchainMessageSigningError(error);
             }
-
-            abortSignal?.throwIfAborted();
 
             if (!output) {
                 throw new TransactionError('SIGNING_FAILED', 'Wallet returned no off-chain message signature');
@@ -128,7 +143,16 @@ export function createOffchainMessageSigner(config: OffchainMessageSignerConfig)
                 },
             };
 
-            await verifyOffchainMessageEnvelope(signedEnvelope);
+            try {
+                await verifyOffchainMessageEnvelope(signedEnvelope);
+            } catch (error) {
+                throw new TransactionError(
+                    'SIGNING_FAILED',
+                    'Off-chain message signature failed verification',
+                    undefined,
+                    error as Error,
+                );
+            }
 
             return {
                 signature: output.signature,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       '@solana-program/system':
         specifier: ^0.12.2
         version: 0.12.2(@solana/kit@7.0.0(bufferutil@4.1.0)(typescript@6.0.3))
-      '@solana/codecs':
-        specifier: ^7.0.0
-        version: 7.0.0(typescript@6.0.3)
       '@solana/connector':
         specifier: workspace:*
         version: link:../../packages/connector
@@ -9381,7 +9378,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.83.7(bufferutil@4.1.0)
-      metro-config: 0.83.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.83.7(bufferutil@4.1.0)
       metro-core: 0.83.7
       semver: 7.8.5
     transitivePeerDependencies:
@@ -14412,6 +14409,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-config@0.83.7(bufferutil@4.1.0):
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.83.7(bufferutil@4.1.0)
+      metro-cache: 0.83.7
+      metro-core: 0.83.7
+      metro-runtime: 0.83.7
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro-config@0.83.7(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       connect: 3.7.0
@@ -14426,6 +14438,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   metro-core@0.83.7:
     dependencies:
@@ -14536,6 +14549,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   metro@0.83.7(bufferutil@4.1.0):
     dependencies:
@@ -14562,7 +14576,7 @@ snapshots:
       metro-babel-transformer: 0.83.7
       metro-cache: 0.83.7
       metro-cache-key: 0.83.7
-      metro-config: 0.83.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.83.7(bufferutil@4.1.0)
       metro-core: 0.83.7
       metro-file-map: 0.83.7
       metro-resolver: 0.83.7
@@ -14628,6 +14642,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   micromatch@4.0.8:
     dependencies:


### PR DESCRIPTION
Stacked on #51. Addresses the findings from the code review of the off-chain message signing feature.

## Connector package

- **Error contract**: `compileOffchainMessageV1Envelope` and `verifyOffchainMessageEnvelope` previously threw raw `SolanaError`s (e.g. `MAXIMUM_LENGTH_EXCEEDED`, `SIGNATURE_VERIFICATION_FAILURE`) that escaped the documented `TransactionError` contract. Both are now normalized to `SIGNING_FAILED` with the original error attached.
- **User rejection**: cancelling the wallet prompt now surfaces as a recoverable `USER_REJECTED` instead of an unrecoverable `SIGNING_FAILED`.
- **Abort semantics**: removed the post-signing `throwIfAborted()` that could discard a signature the user had already approved — matching the documented "abort before it is handed to the wallet" behavior.
- **Defensive feature read**: `supportedMessageVersions` access is now optional-chained, so a nonconforming injected wallet can no longer throw a `TypeError` inside the hook's render-time `useMemo`.
- **`ready` semantics**: `ready` now means "wallet connected" (`Boolean(signer)`), matching `useTransactionSigner`, so consumers can distinguish *disconnected* from *wallet lacks the feature* (previously it was a byte-for-byte duplicate of `canSignOffchainMessage`).
- Tests: wrong-key rejection now asserts the normalized `SIGNING_FAILED` code; new tests for compile-failure normalization and `USER_REJECTED` classification.

## Playground / burner wallet

- Burner wallet registration is now gated to development (or `NEXT_PUBLIC_ENABLE_BURNER_WALLET=true`), keeping the plaintext-localStorage-seed wallet out of production mainnet connect modals.
- Burner `CryptoKey` is no longer extractable; localStorage access survives private browsing / partitioned iframes with an ephemeral in-memory fallback; `resetBurnerWallet` gained SSR/storage guards.
- `#signOffchainMessage` now validates `messageVersion === 1` and that the burner's key appears in `requiredSigners`, per the feature contract (this file is the repo's reference implementation).
- `features` is a stable field instead of a per-read getter; account `features` now list only `solana:*` features.
- Demo distinguishes "connect a wallet" from "wallet lacks the feature" (previously it claimed an unconnected wallet lacked support); dead `disabled={!ready}` guard removed from inside the supported branch.
- Removed the unused `@solana/codecs` dependency and the `OffchainMessageDemo` wiring in the never-mounted `TransactionDemo`.

## Docs

- README `SignInButton` snippet and the playground code sample teach the corrected `ready` / `canSignOffchainMessage` pattern.
- Added `useSignOffchainMessage()` to the bundled skill reference (`connectorkit/references/api.md`), which lists every other hook.

## Verification

- `pnpm --filter @solana/connector test`: 893 passed, 19 skipped (includes 10 OCMS tests, 3 new).
- `tsc --noEmit` clean in `packages/connector` and `examples/next-js` (after building the connector).
- Prettier warnings in 7 files are pre-existing on the base branch and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)