### PR TITLE
fix(connector): bind the wallet's own signature slot, not slot 0

### DIFF
--- a/packages/connector/src/lib/transaction/kit-transaction-signer.test.ts
+++ b/packages/connector/src/lib/transaction/kit-transaction-signer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getBase58Decoder } from '@solana/codecs';
 import { createKitTransactionSigner, createGillTransactionSigner } from './kit-transaction-signer';
 import type { TransactionSigner } from './transaction-signer';
 import type { SolanaTransaction, TransactionSignerCapabilities } from '../../types/transactions';
@@ -89,6 +90,45 @@ describe('KitTransactionSigner', () => {
     describe('createGillTransactionSigner (deprecated alias)', () => {
         it('should be an alias to createKitTransactionSigner', () => {
             expect(createGillTransactionSigner).toBe(createKitTransactionSigner);
+        });
+    });
+
+    describe('signature slot binding', () => {
+        it('binds the wallet signature from its own slot, not the fee payer slot 0', async () => {
+            // v0 message with two signers: index 0 is the fee payer, index 1 is the
+            // connected wallet. The wallet signs a transaction it does not pay fees for.
+            const feePayerKey = new Uint8Array(32).fill(0x0a);
+            const walletKey = new Uint8Array(32).fill(0x0b);
+            const messageBytes = new Uint8Array([0x80, 2, 0, 0, 2, ...feePayerKey, ...walletKey]);
+
+            // Wallet returns the same-length wire tx with only its own slot (index 1)
+            // filled; the fee payer slot 0 is still all zeros.
+            const numSigners = 2;
+            const wireTx = new Uint8Array(1 + numSigners * 64 + messageBytes.length);
+            wireTx[0] = numSigners;
+            wireTx.set(new Uint8Array(64).fill(0xbb), 1 + 64);
+            wireTx.set(messageBytes, 1 + numSigners * 64);
+
+            mockConnectorSigner.signAllTransactions = vi.fn(async () => [wireTx as unknown as SolanaTransaction]);
+
+            vi.mocked(getBase58Decoder).mockReturnValue({
+                decode: (bytes: Uint8Array) => {
+                    if (bytes.length === 32 && bytes[0] === 0x0a) return 'FeePayer1111111111111111111111111111111111';
+                    if (bytes.length === 32 && bytes[0] === 0x0b) return mockAddress;
+                    return 'sig-base58';
+                },
+            } as unknown as ReturnType<typeof getBase58Decoder>);
+
+            const signer = createKitTransactionSigner(mockConnectorSigner);
+            const inputTx = { messageBytes, signatures: {} } as unknown as Parameters<
+                typeof signer.modifyAndSignTransactions
+            >[0][number];
+            const [signed] = await signer.modifyAndSignTransactions([inputTx]);
+
+            // The wallet's signature must come from slot 1 (its own), not slot 0.
+            expect(Array.from(signed.signatures[mockAddress] as unknown as Uint8Array)).toEqual(
+                new Array(64).fill(0xbb),
+            );
         });
     });
 });

--- a/packages/connector/src/lib/transaction/kit-transaction-signer.ts
+++ b/packages/connector/src/lib/transaction/kit-transaction-signer.ts
@@ -246,56 +246,6 @@ function extractSignatureAtIndex(
 }
 
 /**
- * Extract signature bytes from a signed transaction (first signature)
- * @param signedTx - Signed transaction in any format
- * @returns Signature bytes (64 bytes)
- */
-function extractSignature(signedTx: SolanaTransaction): Uint8Array {
-    if (signedTx instanceof Uint8Array) {
-        // Serialized transaction format: [shortvec_length, ...signatures, ...]
-        // First decode the shortvec prefix to find where signatures start
-        const { length: numSignatures, bytesConsumed } = decodeShortVecLength(signedTx);
-
-        if (numSignatures === 0) {
-            throw new Error('No signatures found in serialized transaction');
-        }
-
-        // Extract first 64-byte signature after the shortvec prefix
-        const signatureStart = bytesConsumed;
-        return signedTx.slice(signatureStart, signatureStart + 64);
-    }
-
-    if (isWeb3jsTransaction(signedTx)) {
-        // Extract from web3.js transaction object
-        // Handle both { signature: Uint8Array | null } and raw Uint8Array formats
-        const signatures = (signedTx as unknown as { signatures: Array<Uint8Array | { signature: Uint8Array | null }> })
-            .signatures;
-
-        if (!signatures || signatures.length === 0) {
-            throw new Error('No signatures found in web3.js transaction');
-        }
-
-        const firstSig = signatures[0];
-
-        // Handle raw Uint8Array
-        if (firstSig instanceof Uint8Array) {
-            return firstSig;
-        }
-
-        // Handle { signature: Uint8Array | null } format
-        if (firstSig && typeof firstSig === 'object' && 'signature' in firstSig) {
-            if (firstSig.signature) {
-                return firstSig.signature;
-            }
-        }
-
-        throw new Error('Could not extract signature from web3.js transaction');
-    }
-
-    throw new Error('Cannot extract signature from transaction format');
-}
-
-/**
  * Create a kit-compatible TransactionPartialSigner from connector-kit's TransactionSigner
  *
  * This adapter allows connector-kit to work with modern Solana libraries that use
@@ -340,7 +290,7 @@ export function createKitTransactionSigner<TAddress extends string = string>(
                 const messageBytes = new Uint8Array(tx.messageBytes);
                 // Derive the required signature count from the message header, not from the
                 // current signature dictionary (which is often empty pre-signing).
-                const { numSigners } = parseMessageSigners(messageBytes);
+                const { numSigners, staticAccounts } = parseMessageSigners(messageBytes);
 
                 // Create full transaction wire format for wallet
                 const wireFormat = createTransactionBytesForSigning(messageBytes, numSigners);
@@ -360,6 +310,8 @@ export function createKitTransactionSigner<TAddress extends string = string>(
                     originalTransaction: tx,
                     messageBytes,
                     wireFormat,
+                    staticAccounts,
+                    numSigners,
                 };
             });
 
@@ -369,7 +321,7 @@ export function createKitTransactionSigner<TAddress extends string = string>(
 
             // Extract signatures and return full Transaction objects
             return signedTransactions.map((signedTx, index) => {
-                const { originalTransaction, wireFormat } = transactionData[index];
+                const { originalTransaction, wireFormat, staticAccounts, numSigners } = transactionData[index];
 
                 try {
                     // Get bytes from the signed transaction
@@ -431,8 +383,15 @@ export function createKitTransactionSigner<TAddress extends string = string>(
                         return result as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime;
                     }
 
-                    // Wallet didn't modify - use original messageBytes with wallet signature
-                    const extractedSignatureBytes = extractSignature(signedTxBytes);
+                    // Wallet didn't modify - use original messageBytes with wallet signature.
+                    // Read the signature from the wallet's own slot (its index in the signer
+                    // list), not slot 0: those differ whenever the connected wallet signs a
+                    // transaction whose fee payer is a different account (sponsored/co-signed).
+                    const signerIndex = staticAccounts.indexOf(signerAddress);
+                    if (signerIndex < 0) {
+                        throw new Error('Connected wallet is not a required signer of this transaction');
+                    }
+                    const extractedSignatureBytes = extractSignatureAtIndex(signedTxBytes, signerIndex, numSigners);
                     // Convert to base58 for logging (signature is always 64 bytes)
                     const base58Decoder = getBase58Decoder();
                     const signatureBase58 = base58Decoder.decode(extractedSignatureBytes);


### PR DESCRIPTION
## Summary

In `modifyAndSignTransactions`, after the wallet signs, the connected wallet's signature is read from signature slot 0 and stored under the wallet's address:

```ts
const extractedSignatureBytes = extractSignature(signedTxBytes); // always slot 0
// ...
signatures: Object.freeze({ ...originalTransaction.signatures, [signerAddress]: extractedSignatureBytes }),
```

Slot 0 belongs to the fee payer. A `@solana/kit` signer with address `X` must bind, under key `X`, the signature at `X`'s own index in the compiled message's signer list. Whenever the connected wallet is a required signer but not the fee payer (fee sponsorship, gasless, multi-party co-signing), the wallet fills only its own slot and returns the same-length wire transaction, so this path runs and binds the wallet's address to the still-empty fee-payer slot 0, producing an invalid transaction. When the wallet is the fee payer, slot 0 is its slot, which is why the common case is unaffected.

The correct machinery was already in the file but unused: `extractSignatureAtIndex(signedTx, signerIndex, numSigners)` and `parseMessageSigners`'s `staticAccounts` (the ordered signer list).

## Fix

Look up the wallet's signer index via `staticAccounts.indexOf(signerAddress)` and extract that slot with `extractSignatureAtIndex`. The now-unused slot-0 `extractSignature` helper is removed.

## Test

Added a case building a two-signer message where the connected wallet is signer index 1 (not the fee payer) and returns the wire tx with only its own slot filled. It asserts the bound signature is the wallet's slot, not slot 0. It fails before the fix (binds all-zero slot 0) and passes after.
