### PR TITLE
fix(connector): gate off-chain message signing on account features

### DIFF
--- a/examples/next-js/components/transactions/offchain-message-demo.tsx
+++ b/examples/next-js/components/transactions/offchain-message-demo.tsx
@@ -28,7 +28,13 @@ export function OffchainMessageDemo() {
             setSignature(base58.decode(result.signature));
             setSignedBytes(base58.decode(result.signedOffchainMessage));
         } catch (err) {
-            setError(err instanceof Error ? err.message : 'Failed to sign off-chain message');
+            console.error('signOffchainMessage failed', err);
+            const cause =
+                err && typeof err === 'object' && (err as { originalError?: Error }).originalError instanceof Error
+                    ? (err as { originalError: Error }).originalError
+                    : null;
+            const detail = err instanceof Error ? err.message : 'Failed to sign off-chain message';
+            setError(cause ? `${detail} — ${cause.name}: ${cause.message}` : detail);
         } finally {
             setIsSigning(false);
         }

--- a/packages/connector/src/lib/offchain-message/offchain-message-signer.test.ts
+++ b/packages/connector/src/lib/offchain-message/offchain-message-signer.test.ts
@@ -24,7 +24,12 @@ async function createKeyedAccount() {
     const keyPair = await generateKeyPair();
     const address = await getAddressFromPublicKey(keyPair.publicKey);
     const publicKey = getAddressEncoder().encode(address);
-    const account: WalletAccount = { address, publicKey, chains: ['solana:devnet'], features: [] };
+    const account: WalletAccount = {
+        address,
+        publicKey,
+        chains: ['solana:devnet'],
+        features: [SolanaSignOffchainMessage],
+    };
     return { keyPair, address, account };
 }
 
@@ -105,6 +110,16 @@ describe('createOffchainMessageSigner', () => {
 
         expect(signer.canSignOffchainMessage).toBe(false);
         expect(signer.supportedMessageVersions).toEqual([]);
+        await expect(signer.signOffchainMessage('hi')).rejects.toMatchObject({ code: 'FEATURE_NOT_SUPPORTED' });
+    });
+
+    it('reports no capability when the wallet advertises the feature but the account does not', async () => {
+        const { keyPair, account } = await createKeyedAccount();
+        const accountWithoutFeature: WalletAccount = { ...account, features: [] };
+        const wallet = createOffchainMessageWallet(keyPair);
+        const signer = createOffchainMessageSigner({ wallet, account: accountWithoutFeature })!;
+
+        expect(signer.canSignOffchainMessage).toBe(false);
         await expect(signer.signOffchainMessage('hi')).rejects.toMatchObject({ code: 'FEATURE_NOT_SUPPORTED' });
     });
 

--- a/packages/connector/src/lib/offchain-message/offchain-message-signer.ts
+++ b/packages/connector/src/lib/offchain-message/offchain-message-signer.ts
@@ -83,7 +83,12 @@ export function createOffchainMessageSigner(config: OffchainMessageSignerConfig)
     const feature = (wallet.features as Record<string, unknown>)[SolanaSignOffchainMessage] as
         OffchainMessageFeature | undefined;
     const signerAddress = account.address as Address;
-    const supportsV1 = feature?.supportedMessageVersions?.includes(1) ?? false;
+    // Wallet Standard scopes features per account: `WalletAccount.features` is a subset of the
+    // wallet's, and wallets reject accounts that omit the name even when the wallet advertises it.
+    const accountFeatures: readonly string[] = account.features;
+    const supportsV1 =
+        accountFeatures.includes(SolanaSignOffchainMessage) &&
+        (feature?.supportedMessageVersions?.includes(1) ?? false);
 
     return {
         address: account.address,


### PR DESCRIPTION
Closes DEV-879

## Problem

Wallet Standard scopes features at two levels:

- `Wallet.features` — an `IdentifierRecord` holding the callable method and `supportedMessageVersions`. What the wallet software can do.
- `WalletAccount.features` — an `IdentifierArray` of names only. What *this account* can do. Per `@wallet-standard/base`, it "must be a subset of the names of features of the Wallet."

`createOffchainMessageSigner` only consulted the wallet level. An account can legitimately lack a feature the wallet advertises — hardware-backed, MPC, watch-only, and embedded accounts may not be able to produce off-chain signatures — so `canSignOffchainMessage` returned `true` for accounts that cannot sign. Consumers rendered an enabled affordance and the user hit the failure only after committing to the flow.

Found against Jupiter Wallet 1.16.1, which advertises `solana:signOffchainMessage` with `supportedMessageVersions: [1]` at the wallet layer while the connected account omits the identifier, then enforces the account gate internally and throws `Account does not support off-chain message signing`.

## Change

Require the identifier on both layers. This mirrors two existing precedents:

- `signer-integration.ts` already applies the same account-level gate to `signMessage` and `signAndSendTransaction`, with a comment explaining why.
- `getWalletAccountFeature` in `@wallet-standard/ui` performs exactly this two-step check — account array first, then wallet record — and is what anza's own example panel uses ([anza-xyz/kit#1763](https://github.com/anza-xyz/kit/pull/1763)).

**Scope note:** this does not make such wallets sign — nothing on the dApp side can. It moves the failure from a dead-end click to an accurate capability report, so consumers can disable or hide the affordance.

The playground demo change is separable: it surfaces the wallet's original error, which the previous `catch` discarded by rendering only `err.message`. That discarded cause was the entire diagnosis here, but happy to drop it if you'd rather keep the example minimal.

## Testing

- New case pins the exact shape: wallet advertises the feature, account does not → `canSignOffchainMessage === false` and `FEATURE_NOT_SUPPORTED`.
- Existing fixture account used `features: []` and would have silently failed the new gate; it now lists the identifier.
- `turbo type-check test` green (5/5 tasks). The `next-js` lint failures on this repo are pre-existing and unrelated — `setState` in effect warnings in `wallet-modal.tsx`, `radix-ui/wallet-modal.tsx`, and `featured-section.tsx`.
