### PR TITLE
fix(connector): repair kit-native lifecycle, reset, and status projection (stacked on #56)

### DIFF
--- a/packages/connector/src/__tests__/integration/connector-flow.test.ts
+++ b/packages/connector/src/__tests__/integration/connector-flow.test.ts
@@ -14,6 +14,7 @@ import { MockStorageAdapter } from '../mocks/storage-mock';
 import { createEventCollector, waitForCondition } from '../utils/test-helpers';
 import { waitForConnection, waitForDisconnection } from '../utils/wait-for-state';
 import { createMockWalletAccount, TEST_ADDRESSES } from '../fixtures/accounts';
+import { setupMockWindow, cleanupMockWindow } from '../mocks/window-mock';
 import type { Wallet } from '@wallet-standard/base';
 
 const KIT_WALLET_STORAGE_KEY = 'connector-kit:v1:kit-wallet';
@@ -235,6 +236,45 @@ describe('Connector Flow Integration', () => {
 
             state = client.getSnapshot();
             expect(state.selectedAccount).toBe(TEST_ADDRESSES.ACCOUNT_2);
+        });
+    });
+
+    describe('lifecycle', () => {
+        // React StrictMode mounts effects twice: setup -> cleanup -> setup. The
+        // second setup has to rebuild the wallet client the cleanup tore down.
+        it('rebuilds the wallet client after destroy so connecting still works', async () => {
+            const wallet = createMockPhantomWallet({
+                accounts: [createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1)],
+            });
+            registerWallet(wallet);
+
+            const reinitialize = () => (client as unknown as { initialize: () => void }).initialize();
+
+            await waitForCondition(() => client.getSnapshot().connectors.length > 0, { timeout: 2000 });
+            client.destroy();
+            reinitialize();
+
+            await waitForCondition(() => client.getSnapshot().connectors.length > 0, { timeout: 2000 });
+            await client.select(wallet.name);
+            await waitForConnection(client, 2000);
+
+            expect(client.getSnapshot().connected).toBe(true);
+        });
+
+        it('resetStorage clears the plugin persistence that drives reconnect', () => {
+            setupMockWindow();
+            try {
+                // The plugin owns this key; the configured storage adapters do not
+                // cover it, so resetting only those leaves auto-connect armed and
+                // the next page load silently reconnects.
+                localStorage.setItem(KIT_WALLET_STORAGE_KEY, `Phantom:${TEST_ADDRESSES.ACCOUNT_1}`);
+
+                client.resetStorage();
+
+                expect(localStorage.getItem(KIT_WALLET_STORAGE_KEY)).toBeNull();
+            } finally {
+                cleanupMockWindow();
+            }
         });
     });
 });

--- a/packages/connector/src/lib/core/connector-client.ts
+++ b/packages/connector/src/lib/core/connector-client.ts
@@ -277,6 +277,10 @@ export class ConnectorClient {
             }
         }
 
+        // Reconnect is driven by the wallet plugin's own key, not by the adapters
+        // above, so resetting only those would leave auto-connect armed.
+        this.kitWalletCore.clearPersistedConnection();
+
         this.eventEmitter.emit({
             type: 'storage:reset',
             timestamp: new Date().toISOString(),
@@ -373,5 +377,11 @@ export class ConnectorClient {
         this.kitWalletCore.destroy();
         this.eventEmitter.offAll();
         this.stateManager.clear();
+
+        // KitWalletCore.destroy() releases its client, so the next initialize()
+        // has to rebuild one. Leaving this set would make that call a no-op and
+        // strand the client: StrictMode's setup -> cleanup -> setup cycle (and
+        // any provider remount) would then throw on every connect.
+        this.initialized = false;
     }
 }

--- a/packages/connector/src/lib/wallet/kit-wallet-core.test.ts
+++ b/packages/connector/src/lib/wallet/kit-wallet-core.test.ts
@@ -210,6 +210,68 @@ describe('KitWalletCore', () => {
         expect(events.some(e => e.type === 'wallet:disconnected')).toBe(false);
     });
 
+    it('keeps reporting the live session while another wallet is connecting', async () => {
+        const account = createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1);
+        registerWallet(createMockPhantomWallet({ accounts: [account] }));
+        const solflare = createMockSolflareWallet();
+        // Hold the second connect open so the plugin sits in `status: 'connecting'`
+        // while `connected` still describes Phantom.
+        let releaseConnect: (() => void) | undefined;
+        vi.mocked(solflare.features['standard:connect'].connect).mockImplementation(
+            () => new Promise(resolve => (releaseConnect = () => resolve({ accounts: [] }))),
+        );
+        registerWallet(solflare);
+        const walletCore = createCore();
+
+        await walletCore.connectWallet(createConnectorId('Phantom'));
+        const pending = walletCore.connectWallet(createConnectorId('Solflare'));
+        await waitForCondition(() => releaseConnect !== undefined, { timeout: 2000 });
+
+        const during = stateManager.getSnapshot();
+        expect(during.wallet.status).toBe('connected');
+        expect(during.connected).toBe(true);
+        expect(during.selectedWallet?.name).toBe('Phantom');
+        // The in-flight attempt is still visible to legacy spinners.
+        expect(during.connecting).toBe(true);
+
+        releaseConnect!();
+        await pending.catch(() => {});
+    });
+
+    it('drops account listeners belonging to a previous connection', async () => {
+        const phantomAccount = createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1);
+        registerWallet(createMockPhantomWallet({ accounts: [phantomAccount] }));
+        registerWallet(createMockSolflareWallet({ accounts: [createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_2)] }));
+        const walletCore = createCore();
+
+        await walletCore.connectWallet(createConnectorId('Phantom'));
+        const state = stateManager.getSnapshot();
+        expect(state.wallet.status).toBe('connected');
+        if (state.wallet.status !== 'connected') return;
+
+        const seen: string[][] = [];
+        state.wallet.session.onAccountsChanged(accounts => seen.push(accounts.map(a => String(a.address))));
+
+        await walletCore.connectWallet(createConnectorId('Solflare'));
+
+        // The listener came from Phantom's session; it must not receive Solflare's accounts.
+        expect(seen.flat()).not.toContain(TEST_ADDRESSES.ACCOUNT_2);
+    });
+
+    it('surfaces a failing disconnect instead of silently staying connected', async () => {
+        const account = createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1);
+        const wallet = createMockPhantomWallet({ accounts: [account] });
+        registerWallet(wallet);
+        const walletCore = createCore();
+
+        await walletCore.connectWallet(createConnectorId('Phantom'));
+        vi.mocked(wallet.features['standard:disconnect'].disconnect).mockRejectedValue(new Error('Disconnect failed'));
+        events.length = 0;
+
+        await expect(walletCore.disconnect()).rejects.toThrow('Disconnect failed');
+        expect(events.some(e => e.type === 'error' && e.context === 'disconnect')).toBe(true);
+    });
+
     it('preserves the session across setChain', async () => {
         setupMockWindow();
         try {

--- a/packages/connector/src/lib/wallet/kit-wallet-core.ts
+++ b/packages/connector/src/lib/wallet/kit-wallet-core.ts
@@ -169,7 +169,10 @@ export class KitWalletCore {
     private lastDetectedCount = 0;
     private lastKitStatus: KitWalletState['status'] | null = null;
     private lastNotifiedAccountsKey: string | null = null;
-    private accountsChangedListeners = new Set<(accounts: SessionAccount[]) => void>();
+    private accountsChangedListeners = new Set<{
+        connectorId: WalletConnectorId;
+        listener: (accounts: SessionAccount[]) => void;
+    }>();
 
     constructor(
         private stateManager: StateManager,
@@ -298,7 +301,17 @@ export class KitWalletCore {
         this.connectingConnectorId = null;
         const client = this.client;
         if (!client) return;
-        await client.wallet.disconnect();
+        try {
+            await client.wallet.disconnect();
+        } catch (cause) {
+            // A wallet that rejects `standard:disconnect` would otherwise leave
+            // the projected state on 'connected' with no error surfaced at all.
+            const error = cause instanceof Error ? cause : new Error(String(cause));
+            this.lastError = { error, recoverable: isRecoverableError(error) };
+            this.eventEmitter.emit({ type: 'error', error, context: 'disconnect', timestamp: timestamp() });
+            this.sync();
+            throw error;
+        }
         this.sync();
     }
 
@@ -419,8 +432,14 @@ export class KitWalletCore {
         this.emitConnectionEvents(kitState);
         const accountsKey = session ? session.accounts.map(account => String(account.address)).join(',') : null;
         if (session && accountsKey !== this.lastNotifiedAccountsKey && this.accountsChangedListeners.size > 0) {
-            for (const listener of this.accountsChangedListeners) {
-                listener(session.accounts);
+            for (const entry of this.accountsChangedListeners) {
+                // Listeners from a previous connection are dropped rather than
+                // called with a different wallet's accounts.
+                if (entry.connectorId !== session.connectorId) {
+                    this.accountsChangedListeners.delete(entry);
+                    continue;
+                }
+                entry.listener(session.accounts);
             }
         }
         this.lastNotifiedAccountsKey = accountsKey;
@@ -452,14 +471,12 @@ export class KitWalletCore {
             };
         }
 
-        if (kitState.status === 'connecting' && this.connectingConnectorId) {
-            return {
-                wallet: { status: 'connecting', connectorId: this.connectingConnectorId },
-                legacy: { connected: false, connecting: true },
-                session: null,
-            };
-        }
-
+        // A live connection outranks an in-flight one. The plugin documents
+        // `connected` as independent of `status`: connecting a second wallet
+        // leaves the first connection describing `connected` while `status` is
+        // 'connecting'. Reporting 'connecting' there would flash the whole app
+        // to disconnected (session null) for the length of the popup, even
+        // though the existing wallet is still connected and usable.
         if (kitState.connected) {
             const session = this.buildSession(kitState.connected);
             return {
@@ -471,11 +488,20 @@ export class KitWalletCore {
                         raw: account.account,
                     })),
                     connected: true,
-                    connecting: false,
+                    // Keeps spinners alive while a second wallet is being connected.
+                    connecting: this.connectingConnectorId !== null,
                     selectedAccount: session.selectedAccount.address,
                     selectedWallet: applyWalletIconOverride(getWalletForHandle(kitState.connected.wallet) as Wallet),
                 },
                 session,
+            };
+        }
+
+        if (kitState.status === 'connecting' && this.connectingConnectorId) {
+            return {
+                wallet: { status: 'connecting', connectorId: this.connectingConnectorId },
+                legacy: { ...legacyReset, connecting: true },
+                session: null,
             };
         }
 
@@ -511,8 +537,12 @@ export class KitWalletCore {
             accounts,
             connectorId,
             onAccountsChanged: listener => {
-                this.accountsChangedListeners.add(listener);
-                return () => this.accountsChangedListeners.delete(listener);
+                // Tagged with the connection it was registered on: this callback
+                // belongs to one session, so it must not keep firing with another
+                // wallet's accounts after a switch.
+                const entry = { connectorId, listener };
+                this.accountsChangedListeners.add(entry);
+                return () => this.accountsChangedListeners.delete(entry);
             },
             selectAccount: address => {
                 void this.selectAccount(String(address)).catch((cause: unknown) => {
@@ -620,6 +650,19 @@ export class KitWalletCore {
         const uiAccount = connected.wallet.accounts.find(account => account.address === String(preferredAccount));
         if (uiAccount && uiAccount.address !== connected.account.address) {
             client.wallet.selectAccount(uiAccount);
+        }
+    }
+
+    /**
+     * Clear the plugin's own reconnect persistence. The plugin owns this key, so
+     * clearing the configured storage adapters alone leaves it behind and the
+     * next page load silently reconnects the wallet the caller just forgot.
+     */
+    clearPersistedConnection(): void {
+        try {
+            localStorage.removeItem(KIT_WALLET_STORAGE_KEY);
+        } catch (error) {
+            if (this.options.debug) logger.warn('Failed to clear persisted connection', { error });
         }
     }
 


### PR DESCRIPTION
Stacked on #56. Fixes the confirmed findings from the review of the kit-native rework. Five fixes, each with a regression test verified to fail without it.

## `ConnectorClient.destroy()` stranded the wallet client — dev-mode connect was broken

`KitWalletCore.destroy()` releases its client and resets its own `started` flag, but `ConnectorClient.initialized` was never reset. The provider calls `initialize()` on effect setup and `destroy()` on cleanup, so React StrictMode's setup → cleanup → setup cycle left the client torn down and never rebuilt — `initialize()` early-returned, `start()` never ran again, and **every subsequent connect threw `Wallet client not initialized`**. Same for any provider unmount/remount. This worked before the rework because `ConnectionManager` connected through the wallet object directly.

## `resetStorage()` no longer disabled auto-reconnect

Reconnect is driven by the plugin's own `connector-kit:v1:kit-wallet` key, which `resetStorage()` never touched — it only reset the `config.storage.{account,wallet,cluster}` adapters. A user who reset storage to forget their wallet got silently reconnected on the next page load. Adds `KitWalletCore.clearPersistedConnection()` (the core owns that key) and calls it from `resetStorage()`.

## `projectStatus()` reported a connected app as disconnected

The `connecting` branch preceded `connected`, but the plugin documents `connected` as **independent of `status`**: connecting a second wallet leaves the first connection describing `connected` while `status` is `'connecting'` (`@solana/kit-plugin-wallet` `types.d.ts`). So for the length of the second wallet's popup the app reported `session: null` / `connected: false` — flipping `useWallet().isConnected` false and unmounting connected UI — while `selectedWallet` stayed populated from the first wallet. A live connection now wins; legacy `connecting` still reflects the in-flight attempt so spinners keep working.

## `disconnect()` swallowed failures

No error handling, unlike `connectWallet()`: a rejecting `standard:disconnect` skipped `sync()`, emitted no error event, and left the projected state on `connected` while the caller got an unhandled rejection. Now emits an `error` event with `context: 'disconnect'`, re-syncs, and rethrows.

## Session account listeners outlived their session

`session.onAccountsChanged` registered into a core-level `Set`, so a listener obtained from wallet A's session kept firing after a switch — with wallet B's accounts. Listeners are now tagged with the connection they were registered on and dropped on switch.

## Verification

- `pnpm --filter @solana/connector test`: **873 passed**, 19 skipped (up from 868 — five new tests).
- Each new test confirmed to fail against the unfixed source and pass with the fix.
- `tsc --noEmit` clean; Prettier clean on all changed files.

## Deliberately not changed

- **`ready: true` / `connectable: true` hardcoded in `toConnectorMetadata`/`toWalletInfo`** — reviewed and found correct. The plugin only surfaces wallets supporting the configured chain *and* `standard:connect`, exactly the old `hasConnect && isSolana` gate. Only side effect is cosmetic: the playground's `notReadyConnectors` bucket is now always empty.
- **`signer-integration.ts` devnet fallback** — real (localnet binds to devnet) but pre-existing; `main` has the same default using genesis-hash chain ids. Worth a separate fix, not a regression from #56.
- **`useBalance` coupling `liveUpdates` to `autoRefresh`** — every `useBalance()` now opens a WebSocket subscription by default and the only opt-out also kills polling. Documented behavior, so left as a design call for the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)