### PR TITLE
fix(connector): address confirmed review findings from the kit-native rework

### DIFF
--- a/.changeset/kit-native-review-fixes.md
+++ b/.changeset/kit-native-review-fixes.md
@@ -1,0 +1,38 @@
+---
+'@solana/connector': patch
+---
+
+Fix regressions found in review of the kit-native rework:
+
+- Re-initialize cleanly after `destroy()` — React StrictMode's dev
+  unmount/remount cycle no longer leaves the wallet client permanently torn
+  down ("Wallet client not initialized" on every connect).
+- Preserve wallet values persisted by pre-plugin releases (bare wallet name)
+  instead of letting the plugin erase them and silently log the user out once
+  on upgrade; the next connect upgrades the value to the new format.
+- Cluster switches no longer block on the replacement wallet client's
+  unbounded silent-reconnect warm-up, and a failed silent reconnect during
+  the switch no longer wipes the persisted session.
+- `onAccountsChanged` listeners are cleared when their session ends, so a
+  dead session's listeners no longer fire with the next session's accounts.
+- `selectAccount` regains the pre-plugin re-authorize fallback: on a miss it
+  re-invokes the wallet's connect to refresh the authorized accounts before
+  failing.
+- Interval polling in `useBalance`/`useTokens` keeps running under live
+  account subscriptions (the subscription only watches the system account, so
+  SPL token changes previously went stale once it loaded); subscriptions now
+  purely add push immediacy.
+- One shared `SolanaClient` (and WebSocket transport) per RPC URL across
+  hooks, instead of one socket per hook instance.
+- `prepareTransaction` gains an `estimateResources: false` opt-out for
+  blockhash-only preparation, accepting a plain `Rpc<GetLatestBlockhashApi>`
+  (also on `useTransactionPreparer` options).
+- `createKitSignersFromWallet` warns and omits the transaction signer for
+  unrecognized RPC endpoints instead of throwing (and still does not guess a
+  chain).
+- `useKitTransactionSigner` derives the chain from the cluster (fixing
+  `solana:mainnet-beta` and URL-detected local clusters), accepts an explicit
+  `chain` override for custom clusters, and reports a `reason` when no signer
+  is available.
+- Deprecated the no-op `ConnectOptions.silent` / `allowInteractiveFallback`
+  fields; silent session restore happens via `autoConnect` persistence.

--- a/connectorkit/references/api.md
+++ b/connectorkit/references/api.md
@@ -40,7 +40,9 @@ const {
 } = useConnectWallet();
 
 // ConnectOptions:
-// { silent?: boolean, allowInteractiveFallback?: boolean, preferredAccount?: Address }
+// { preferredAccount?: Address }
+// (silent / allowInteractiveFallback are deprecated no-ops; silent restore
+//  happens automatically via autoConnect persistence)
 ```
 
 ### useDisconnectWallet()

--- a/packages/connector/README.md
+++ b/packages/connector/README.md
@@ -470,25 +470,18 @@ function DisconnectButton() {
 }
 ```
 
-### Silent-First Auto-Connect
+### Silent Session Restore
 
-The vNext API supports silent-first auto-connect, which attempts to reconnect without prompting the user:
+Silent reconnection is handled automatically: with `autoConnect` enabled (the default), the wallet plugin silently restores the persisted session on startup without prompting the user. Explicit `connect()` calls are always interactive.
 
 ```typescript
-const { connect } = useConnectWallet();
-
-// Silent connect (won't prompt user)
-await connect('wallet-standard:phantom', {
-    silent: true,
-    allowInteractiveFallback: false,
-});
-
-// Silent-first with interactive fallback (prompts if silent fails)
-await connect('wallet-standard:phantom', {
-    silent: true,
-    allowInteractiveFallback: true,
+const config = getDefaultConfig({
+    appName: 'My App',
+    autoConnect: true, // silent restore of the persisted session on load
 });
 ```
+
+> The `silent` and `allowInteractiveFallback` fields on `ConnectOptions` are deprecated no-ops under the kit wallet plugin backend and will be removed in the next major.
 
 ---
 
@@ -1416,7 +1409,7 @@ Storage uses nanostores with built-in enhancements that are **automatically appl
 - Additional validation rules
 - Custom error tracking
 
-**Auto-connect persistence is separate from `storage.wallet`.** The wallet session is persisted by the underlying `@solana/kit-plugin-wallet` client under the `connector-kit:v1:kit-wallet` localStorage key, and silent reconnect reads that key directly. `storage.wallet` still receives the connected wallet's name, but pointing it at a different backend does not move where reconnect state lives — auto-connect requires `localStorage` and is unavailable in environments without it (React Native, SSR).
+**`storage.wallet` is the auto-connect source when supplied.** The wallet plugin persists the active connection as `<wallet name>:<account address>` through `storage.wallet` when one is configured (the default config always supplies one), and silent reconnect reads it back from there; without an adapter it falls back to the `connector-kit:v1:kit-wallet` localStorage key. Values persisted by pre-plugin releases (a bare wallet name) are preserved untouched until the next connect overwrites them in the new format — they are not used for reconnection.
 
 ```typescript
 import { getDefaultConfig, createEnhancedStorageWallet, EnhancedStorageAdapter } from '@solana/connector';

--- a/packages/connector/src/__tests__/mocks/wallet-standard-mock.ts
+++ b/packages/connector/src/__tests__/mocks/wallet-standard-mock.ts
@@ -123,7 +123,25 @@ export function createMockWallet(options: MockWalletOptions): StandardWallet {
         },
     };
 
+    Object.defineProperty(wallet, '__setAccountsSilently', {
+        value: (accounts: WalletAccount[]) => {
+            currentAccounts = [...accounts];
+        },
+        enumerable: false,
+    });
+
     return wallet;
+}
+
+/**
+ * Update a mock wallet's accounts without emitting a `change` event,
+ * simulating an authorization the wallet holds but has not propagated
+ * through `standard:events` yet.
+ */
+export function setMockWalletAccountsSilently(wallet: StandardWallet, accounts: WalletAccount[]): void {
+    (wallet as unknown as { __setAccountsSilently: (accounts: WalletAccount[]) => void }).__setAccountsSilently(
+        accounts,
+    );
 }
 
 export function createMockPhantomWallet(overrides?: Partial<MockWalletOptions>): StandardWallet {

--- a/packages/connector/src/headless.ts
+++ b/packages/connector/src/headless.ts
@@ -213,6 +213,7 @@ export type {
     CreateSolanaClientArgs,
     GetExplorerLinkArgs,
     PrepareTransactionConfig,
+    PrepareTransactionConfigWithoutEstimation,
 } from './lib/kit';
 
 // ============================================================================

--- a/packages/connector/src/hooks/_internal/use-wallet-assets.test.ts
+++ b/packages/connector/src/hooks/_internal/use-wallet-assets.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+import { useWalletAssets } from './use-wallet-assets';
+import { clearSharedQueryCache } from './use-shared-query';
+import { TEST_ADDRESSES } from '../../__tests__/fixtures/accounts';
+
+vi.mock('@solana/react', () => ({ useSubscription: vi.fn() }));
+vi.mock('../use-wallet', () => ({ useWallet: vi.fn() }));
+vi.mock('../use-kit-solana-client', () => ({ useSolanaClient: vi.fn() }));
+
+const { useSubscription } = await import('@solana/react');
+const { useWallet } = await import('../use-wallet');
+const { useSolanaClient } = await import('../use-kit-solana-client');
+
+interface MockSubscriptionState {
+    data: unknown;
+    error: unknown;
+    status: string;
+}
+
+describe('useWalletAssets', () => {
+    let getBalance: ReturnType<typeof vi.fn>;
+    let getTokenAccountsByOwner: ReturnType<typeof vi.fn>;
+    let accountNotifications: ReturnType<typeof vi.fn>;
+    let subscriptionState: MockSubscriptionState;
+    let lamports: bigint;
+
+    const makeClient = () => ({
+        urlOrMoniker: 'https://rpc.test.example',
+        rpc: { getBalance, getTokenAccountsByOwner },
+        rpcSubscriptions: { accountNotifications },
+    });
+
+    beforeEach(() => {
+        clearSharedQueryCache();
+        lamports = 1000n;
+        getBalance = vi.fn(() => ({ send: async () => ({ value: lamports }) }));
+        getTokenAccountsByOwner = vi.fn(() => ({ send: async () => ({ value: [] }) }));
+        accountNotifications = vi.fn(() => ({ subscription: 'source' }));
+        subscriptionState = { data: undefined, error: null, status: 'connecting' };
+
+        vi.mocked(useSubscription).mockImplementation(
+            () => subscriptionState as unknown as ReturnType<typeof useSubscription>,
+        );
+        vi.mocked(useWallet).mockReturnValue({
+            account: TEST_ADDRESSES.ACCOUNT_1,
+            isConnected: true,
+        } as unknown as ReturnType<typeof useWallet>);
+        vi.mocked(useSolanaClient).mockImplementation(
+            () =>
+                ({
+                    client: makeClient(),
+                    ready: true,
+                    clusterType: 'devnet',
+                }) as unknown as ReturnType<typeof useSolanaClient>,
+        );
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.clearAllMocks();
+    });
+
+    it('keeps polling after the subscription reports loaded', async () => {
+        vi.useFakeTimers();
+        const { rerender } = renderHook(() => useWalletAssets({ liveUpdates: true, refetchIntervalMs: 500 }));
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        // The subscription is live — the wallet system account delivered data.
+        // SPL token changes never notify it, so polling must not stop.
+        subscriptionState = { data: { value: { lamports: 1000n } }, error: null, status: 'loaded' };
+        await act(async () => {
+            rerender();
+        });
+        const callsAfterLoad = getBalance.mock.calls.length;
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(1600);
+        });
+
+        expect(getBalance.mock.calls.length).toBeGreaterThanOrEqual(callsAfterLoad + 2);
+    });
+
+    it('applies pushed lamports to the shared cache immediately and refetches once', async () => {
+        const { result, rerender } = renderHook(() => useWalletAssets({ liveUpdates: true }));
+        await waitFor(() => expect(result.current.data?.lamports).toBe(1000n));
+        const callsBeforePush = getBalance.mock.calls.length;
+
+        lamports = 5000n;
+        subscriptionState = { data: { value: { lamports: 5000n } }, error: null, status: 'loaded' };
+        await act(async () => {
+            rerender();
+        });
+
+        // The pushed value is visible without waiting for the refetch...
+        expect(result.current.data?.lamports).toBe(5000n);
+        // ...and one full refetch runs to pick up token deltas.
+        await waitFor(() => expect(getBalance.mock.calls.length).toBe(callsBeforePush + 1));
+        await waitFor(() => expect(result.current.data?.lamports).toBe(5000n));
+    });
+
+    it('ignores notifications for accounts that do not exist on chain', async () => {
+        const { result, rerender } = renderHook(() => useWalletAssets({ liveUpdates: true }));
+        await waitFor(() => expect(result.current.data?.lamports).toBe(1000n));
+        const callsBefore = getBalance.mock.calls.length;
+
+        subscriptionState = { data: { value: null }, error: null, status: 'loaded' };
+        await act(async () => {
+            rerender();
+        });
+
+        expect(result.current.data?.lamports).toBe(1000n);
+        expect(getBalance.mock.calls.length).toBe(callsBefore);
+    });
+
+    it('does not subscribe when liveUpdates is disabled', async () => {
+        const { result } = renderHook(() => useWalletAssets());
+        await waitFor(() => expect(result.current.data).toBeDefined());
+
+        expect(accountNotifications).not.toHaveBeenCalled();
+        expect(vi.mocked(useSubscription)).toHaveBeenLastCalledWith(null);
+    });
+});

--- a/packages/connector/src/hooks/_internal/use-wallet-assets.ts
+++ b/packages/connector/src/hooks/_internal/use-wallet-assets.ts
@@ -66,10 +66,10 @@ export interface UseWalletAssetsOptions<TSelected = WalletAssetsData> extends Om
     select?: (data: WalletAssetsData | undefined) => TSelected;
     /**
      * Subscribe to wallet account notifications for push-based updates.
-     * Once the subscription has delivered data it supersedes
-     * `refetchIntervalMs` polling; while it is connecting, after it errors,
-     * or when WebSocket transport is unavailable, polling runs as the
-     * fallback (so a fallback requires `refetchIntervalMs` to be set).
+     * The subscription adds immediacy on top of `refetchIntervalMs` polling —
+     * it does not replace it: it only observes the wallet's system account,
+     * so token-account changes still arrive via the poll (and a socket that
+     * closes cleanly surfaces no error to react to).
      * (default: false)
      */
     liveUpdates?: boolean;
@@ -312,18 +312,18 @@ export function useWalletAssets<TSelected = WalletAssetsData>(
         return rpcClient.rpcSubscriptions.accountNotifications(toAddress(address));
     }, [liveUpdates, key, address, rpcClient]);
 
-    const {
-        data: accountNotification,
-        error: subscriptionError,
-        status: subscriptionStatus,
-    } = useSubscription(accountNotificationsSource);
+    const { data: accountNotification, error: subscriptionError } = useSubscription(accountNotificationsSource);
 
     useEffect(() => {
         // `value` is null when the account does not exist on chain (unfunded,
         // or closed and purged), in which case there is no balance to apply.
         if (!key || !accountNotification?.value) return;
         const lamports = accountNotification.value.lamports;
-        // Apply the new balance immediately, then refetch to pick up token deltas
+        // Apply the new balance immediately, then refetch to pick up token
+        // deltas. The refetch re-runs the full query fn — including a
+        // getBalance the push already answered — because a partial fetch
+        // would bypass the shared query's in-flight dedup and cost more
+        // across hook instances than the one redundant call.
         setSharedQueryData<WalletAssetsData>(key, prev =>
             !prev || prev.lamports === lamports ? prev : { ...prev, lamports },
         );
@@ -332,16 +332,14 @@ export function useWalletAssets<TSelected = WalletAssetsData>(
 
     useEffect(() => {
         if (!subscriptionError) return;
-        logger.warn('Account subscription errored; falling back to polling', { error: subscriptionError });
+        logger.warn('Account subscription errored; polling continues to cover updates', { error: subscriptionError });
     }, [subscriptionError]);
 
-    // Polling yields only to a subscription that has delivered data; while it
-    // is still connecting (or after it errors) polling keeps running so a hung
-    // WebSocket cannot freeze balances.
-    const subscriptionActive = accountNotificationsSource !== null && subscriptionStatus === 'loaded';
-    const effectiveRefetchIntervalMs = subscriptionActive ? false : refetchIntervalMs;
-
-    // Use shared query with optional select
+    // Polling never yields to the subscription: it only observes the wallet's
+    // system account, so SPL token movements (which mutate ATAs) emit no
+    // notification, and a WebSocket that closes cleanly parks the
+    // subscription in its last status with no error to react to. The
+    // subscription's job is immediacy, not replacement.
     const { data, error, status, updatedAt, isFetching, refetch, abort } = useSharedQuery<WalletAssetsData, TSelected>(
         key,
         queryFn,
@@ -350,7 +348,7 @@ export function useWalletAssets<TSelected = WalletAssetsData>(
             staleTimeMs,
             cacheTimeMs,
             refetchOnMount,
-            refetchIntervalMs: effectiveRefetchIntervalMs,
+            refetchIntervalMs,
             select: select as ((data: WalletAssetsData | undefined) => TSelected) | undefined,
         },
     );

--- a/packages/connector/src/hooks/use-balance.ts
+++ b/packages/connector/src/hooks/use-balance.ts
@@ -137,7 +137,7 @@ function selectBalance(assets: WalletAssetsData | undefined): BalanceSelection {
  * - Automatic request deduplication across components
  * - Shared data with useTokens (single RPC query)
  * - Token-2022 support
- * - Live balance updates via account subscription (with polling fallback)
+ * - Live balance updates via account subscription, with interval polling always running alongside
  * - Configurable auto-refresh behavior
  * - Abort support for in-flight requests
  * - Optional client override

--- a/packages/connector/src/hooks/use-connect-wallet.ts
+++ b/packages/connector/src/hooks/use-connect-wallet.ts
@@ -32,7 +32,7 @@ export interface UseConnectWalletReturn {
      * Connect to a wallet by connector ID.
      *
      * @param connectorId - Stable connector identifier (e.g., 'wallet-standard:phantom')
-     * @param options - Connection options (silent mode, preferred account)
+     * @param options - Connection options (preferred account)
      */
     connect: (connectorId: WalletConnectorId, options?: ConnectOptions) => Promise<void>;
 
@@ -54,7 +54,7 @@ export interface UseConnectWalletReturn {
 
 /**
  * Hook to connect to a wallet by connector ID.
- * Uses the vNext connectWallet API with silent-first support.
+ * Uses the vNext connectWallet API.
  */
 export function useConnectWallet(): UseConnectWalletReturn {
     const client = useContext(ConnectorContext);

--- a/packages/connector/src/hooks/use-kit-solana-client.test.tsx
+++ b/packages/connector/src/hooks/use-kit-solana-client.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import { useSolanaClient, useGillSolanaClient } from './use-kit-solana-client';
+import { useSolanaClient, useGillSolanaClient, clearSharedSolanaClientCache } from './use-kit-solana-client';
 import { ConnectorProvider } from '../ui/connector-provider';
 import type { ReactNode } from 'react';
 import type { ExtendedConnectorConfig } from '../config/default-config';
@@ -30,6 +30,31 @@ describe('useSolanaClient', () => {
         // Without a cluster selected, client should be null and ready should be false
         expect(result.current.client).toBeNull();
         expect(result.current.ready).toBe(false);
+    });
+
+    describe('shared client cache', () => {
+        beforeEach(() => {
+            clearSharedSolanaClientCache();
+        });
+
+        it('shares one client (and its subscription transport) across hook instances', () => {
+            const { result: first } = renderHook(() => useSolanaClient(), { wrapper });
+            const { result: second } = renderHook(() => useSolanaClient(), { wrapper });
+
+            expect(first.current.client).not.toBeNull();
+            expect(first.current.client).toBe(second.current.client);
+        });
+
+        it('returns a fresh client after the cache is cleared', () => {
+            const { result: first } = renderHook(() => useSolanaClient(), { wrapper });
+            expect(first.current.client).not.toBeNull();
+
+            clearSharedSolanaClientCache();
+            const { result: second } = renderHook(() => useSolanaClient(), { wrapper });
+
+            expect(second.current.client).not.toBeNull();
+            expect(second.current.client).not.toBe(first.current.client);
+        });
     });
 
     describe('useGillSolanaClient (deprecated alias)', () => {

--- a/packages/connector/src/hooks/use-kit-solana-client.test.tsx
+++ b/packages/connector/src/hooks/use-kit-solana-client.test.tsx
@@ -1,59 +1,78 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useSolanaClient, useGillSolanaClient, clearSharedSolanaClientCache } from './use-kit-solana-client';
-import { ConnectorProvider } from '../ui/connector-provider';
-import type { ReactNode } from 'react';
-import type { ExtendedConnectorConfig } from '../config/default-config';
+import { useCluster } from './use-cluster';
+import { useConnectorClient } from '../ui/connector-provider';
+import type { ClusterType } from '../utils/cluster';
+
+vi.mock('./use-cluster', () => ({ useCluster: vi.fn() }));
+vi.mock('../ui/connector-provider', async importOriginal => {
+    const actual = await importOriginal<typeof import('../ui/connector-provider')>();
+    return { ...actual, useConnectorClient: vi.fn() };
+});
+
+function mockEnv(type: ClusterType | null, getRpcUrl: () => string | null) {
+    vi.mocked(useCluster).mockReturnValue({ type } as unknown as ReturnType<typeof useCluster>);
+    vi.mocked(useConnectorClient).mockReturnValue({ getRpcUrl } as unknown as ReturnType<typeof useConnectorClient>);
+}
 
 describe('useSolanaClient', () => {
-    const mockConfig: ExtendedConnectorConfig = {
-        cluster: {
-            clusters: [{ id: 'solana:devnet', label: 'Devnet', url: 'https://api.devnet.solana.com' }],
-        },
-    };
-
-    const wrapper = ({ children }: { children: ReactNode }) => (
-        <ConnectorProvider config={mockConfig}>{children}</ConnectorProvider>
-    );
-
-    it.skip('should return client and ready status', () => {
-        const { result } = renderHook(() => useSolanaClient(), { wrapper });
-
-        expect(result.current).toHaveProperty('client');
-        expect(result.current).toHaveProperty('ready');
-        expect(typeof result.current.ready).toBe('boolean');
-    });
-
-    it.skip('should return null client when not ready', () => {
-        const { result } = renderHook(() => useSolanaClient(), { wrapper });
-
-        // Without a cluster selected, client should be null and ready should be false
-        expect(result.current.client).toBeNull();
-        expect(result.current.ready).toBe(false);
+    beforeEach(() => {
+        vi.mocked(useCluster).mockReset();
+        vi.mocked(useConnectorClient).mockReset();
+        clearSharedSolanaClientCache();
     });
 
     describe('shared client cache', () => {
-        beforeEach(() => {
-            clearSharedSolanaClientCache();
-        });
-
         it('shares one client (and its subscription transport) across hook instances', () => {
-            const { result: first } = renderHook(() => useSolanaClient(), { wrapper });
-            const { result: second } = renderHook(() => useSolanaClient(), { wrapper });
+            mockEnv('devnet', () => 'https://api.devnet.solana.com');
+
+            const { result: first } = renderHook(() => useSolanaClient());
+            const { result: second } = renderHook(() => useSolanaClient());
 
             expect(first.current.client).not.toBeNull();
             expect(first.current.client).toBe(second.current.client);
         });
 
         it('returns a fresh client after the cache is cleared', () => {
-            const { result: first } = renderHook(() => useSolanaClient(), { wrapper });
+            mockEnv('devnet', () => 'https://api.devnet.solana.com');
+
+            const { result: first } = renderHook(() => useSolanaClient());
             expect(first.current.client).not.toBeNull();
 
             clearSharedSolanaClientCache();
-            const { result: second } = renderHook(() => useSolanaClient(), { wrapper });
+            const { result: second } = renderHook(() => useSolanaClient());
 
             expect(second.current.client).not.toBeNull();
             expect(second.current.client).not.toBe(first.current.client);
+        });
+
+        it('swaps clients when switching between two custom clusters', () => {
+            // Same cluster type ('custom') and same connector client identity
+            // across the switch — only the resolved RPC URL changes, which is
+            // exactly what the memo must react to.
+            let url = 'https://rpc-a.example.com';
+            mockEnv('custom', () => url);
+
+            const { result, rerender } = renderHook(() => useSolanaClient());
+            const clientA = result.current.client;
+            expect(clientA).not.toBeNull();
+
+            url = 'https://rpc-b.example.com';
+            rerender();
+
+            expect(result.current.client).not.toBeNull();
+            expect(result.current.client).not.toBe(clientA);
+            expect(String(result.current.client?.urlOrMoniker)).toContain('rpc-b.example.com');
+        });
+
+        it('returns null for a custom cluster without a configured RPC URL', () => {
+            mockEnv('custom', () => null);
+
+            const { result } = renderHook(() => useSolanaClient());
+
+            expect(result.current.client).toBeNull();
+            expect(result.current.ready).toBe(false);
         });
     });
 

--- a/packages/connector/src/hooks/use-kit-solana-client.ts
+++ b/packages/connector/src/hooks/use-kit-solana-client.ts
@@ -124,12 +124,17 @@ export function useSolanaClient(): UseSolanaClientReturn {
     const { type } = useCluster();
     const connectorClient = useConnectorClient();
 
+    // Read the URL every render and key the memo on it: the cluster type
+    // alone misses a switch between two custom clusters ('custom' both
+    // before and after while the URL changes). useCluster subscribes to
+    // cluster state, so a switch re-renders this hook.
+    const rpcUrl = connectorClient?.getRpcUrl() ?? null;
+
     const client = useMemo(() => {
         if (!type || !connectorClient) return null;
 
         try {
             // ALWAYS prefer the configured RPC URL from cluster config
-            const rpcUrl = connectorClient.getRpcUrl();
             if (rpcUrl) {
                 return getSharedSolanaClient(rpcUrl as ModifiedClusterUrl);
             }
@@ -144,7 +149,7 @@ export function useSolanaClient(): UseSolanaClientReturn {
             logger.error('Failed to create Solana client', { error });
             return null;
         }
-    }, [type, connectorClient]);
+    }, [type, connectorClient, rpcUrl]);
 
     // Memoize return object to prevent infinite re-renders in consumers
     return useMemo(

--- a/packages/connector/src/hooks/use-kit-solana-client.ts
+++ b/packages/connector/src/hooks/use-kit-solana-client.ts
@@ -9,12 +9,39 @@
 
 import { useMemo } from 'react';
 import { createSolanaClient, type SolanaClient, type ModifiedClusterUrl } from '../lib/kit';
+import { resolveRpcUrl } from '../lib/kit/client';
+import type { SolanaClientUrlOrMoniker } from '../lib/kit/rpc';
 import { useCluster } from './use-cluster';
 import { useConnectorClient } from '../ui/connector-provider';
 import type { ClusterType } from '../utils/cluster';
 import { createLogger } from '../lib/utils/secure-logger';
 
 const logger = createLogger('useSolanaClient');
+
+/**
+ * One client per resolved RPC URL, shared across all hook instances.
+ * Kit's subscription transport only coalesces identical subscriptions within
+ * a single transport, so per-hook clients would open one WebSocket per hook;
+ * sharing the client makes N hooks share one socket. An idle cached client
+ * holds no sockets (channels open lazily on the first subscription and close
+ * when the last one ends), so entries never need disposal.
+ */
+const sharedClients = new Map<string, SolanaClient>();
+
+function getSharedSolanaClient(urlOrMoniker: SolanaClientUrlOrMoniker): SolanaClient {
+    const key = resolveRpcUrl(urlOrMoniker).toString();
+    let client = sharedClients.get(key);
+    if (!client) {
+        client = createSolanaClient({ urlOrMoniker: urlOrMoniker as ModifiedClusterUrl });
+        sharedClients.set(key, client);
+    }
+    return client;
+}
+
+/** Test-only escape hatch; not exported from the package entrypoints. */
+export function clearSharedSolanaClientCache(): void {
+    sharedClients.clear();
+}
 
 /**
  * Return value from useSolanaClient hook
@@ -104,16 +131,12 @@ export function useSolanaClient(): UseSolanaClientReturn {
             // ALWAYS prefer the configured RPC URL from cluster config
             const rpcUrl = connectorClient.getRpcUrl();
             if (rpcUrl) {
-                return createSolanaClient({
-                    urlOrMoniker: rpcUrl as ModifiedClusterUrl,
-                });
+                return getSharedSolanaClient(rpcUrl as ModifiedClusterUrl);
             }
 
             // Fallback to moniker only if no RPC URL configured
             if (type !== 'custom') {
-                return createSolanaClient({
-                    urlOrMoniker: type,
-                });
+                return getSharedSolanaClient(type);
             }
 
             return null;

--- a/packages/connector/src/hooks/use-kit-transaction-signer.test.tsx
+++ b/packages/connector/src/hooks/use-kit-transaction-signer.test.tsx
@@ -94,12 +94,15 @@ describe('useKitTransactionSigner', () => {
 
         it('reports disconnected when no wallet is connected', () => {
             vi.mocked(useConnector).mockReturnValue(
-                connectorState({ id: 'solana:devnet', label: 'Devnet', url: 'https://api.devnet.solana.com' }, {
-                    connected: false,
-                    selectedWallet: null,
-                    accounts: [],
-                    selectedAccount: null,
-                }),
+                connectorState(
+                    { id: 'solana:devnet', label: 'Devnet', url: 'https://api.devnet.solana.com' },
+                    {
+                        connected: false,
+                        selectedWallet: null,
+                        accounts: [],
+                        selectedAccount: null,
+                    },
+                ),
             );
 
             const { result } = renderHook(() => useKitTransactionSigner());

--- a/packages/connector/src/hooks/use-kit-transaction-signer.test.tsx
+++ b/packages/connector/src/hooks/use-kit-transaction-signer.test.tsx
@@ -1,8 +1,32 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
+import type { SolanaCluster } from '@wallet-ui/core';
 import { useKitTransactionSigner, useGillTransactionSigner } from './use-kit-transaction-signer';
-import { ConnectorProvider } from '../ui/connector-provider';
+import { ConnectorProvider, useConnector } from '../ui/connector-provider';
+import { createMockPhantomWallet } from '../__tests__/mocks/wallet-standard-mock';
+import { createMockWalletAccount, TEST_ADDRESSES } from '../__tests__/fixtures/accounts';
 import type { ReactNode } from 'react';
+
+vi.mock('../ui/connector-provider', async importOriginal => {
+    const actual = await importOriginal<typeof import('../ui/connector-provider')>();
+    return { ...actual, useConnector: vi.fn() };
+});
+
+function connectorState(cluster: SolanaCluster | null, overrides: Record<string, unknown> = {}) {
+    const account = createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1, {
+        chains: ['solana:mainnet', 'solana:devnet', 'solana:testnet'],
+        features: ['solana:signTransaction'],
+    });
+    const wallet = createMockPhantomWallet({ accounts: [account], features: ['solana:signTransaction'] });
+    return {
+        connected: true,
+        selectedWallet: wallet,
+        selectedAccount: TEST_ADDRESSES.ACCOUNT_1,
+        accounts: [{ address: TEST_ADDRESSES.ACCOUNT_1, raw: account }],
+        cluster,
+        ...overrides,
+    } as unknown as ReturnType<typeof useConnector>;
+}
 
 describe('useKitTransactionSigner', () => {
     const mockConfig = {
@@ -12,6 +36,10 @@ describe('useKitTransactionSigner', () => {
     const wrapper = ({ children }: { children: ReactNode }) => (
         <ConnectorProvider config={mockConfig}>{children}</ConnectorProvider>
     );
+
+    beforeEach(() => {
+        vi.mocked(useConnector).mockReset();
+    });
 
     it.skip('should return signer and ready status', () => {
         const { result } = renderHook(() => useKitTransactionSigner(), { wrapper });
@@ -26,6 +54,59 @@ describe('useKitTransactionSigner', () => {
 
         expect(result.current.signer).toBeNull();
         expect(result.current.ready).toBe(false);
+    });
+
+    describe('chain derivation', () => {
+        it('builds a signer for the solana:mainnet-beta cluster id', () => {
+            vi.mocked(useConnector).mockReturnValue(
+                connectorState({ id: 'solana:mainnet-beta', label: 'Mainnet', url: 'https://rpc.example.com' }),
+            );
+
+            const { result } = renderHook(() => useKitTransactionSigner());
+
+            expect(result.current.signer).not.toBeNull();
+            expect(result.current.ready).toBe(true);
+            expect(result.current.reason).toBeNull();
+        });
+
+        it('reports unsupported-chain for a custom cluster instead of silently disabling', () => {
+            vi.mocked(useConnector).mockReturnValue(
+                connectorState({ id: 'solana:my-fork', label: 'Fork', url: 'https://rpc.example.com' }),
+            );
+
+            const { result } = renderHook(() => useKitTransactionSigner());
+
+            expect(result.current.signer).toBeNull();
+            expect(result.current.ready).toBe(false);
+            expect(result.current.reason).toBe('unsupported-chain');
+        });
+
+        it('builds a signer for a custom cluster with an explicit chain override', () => {
+            vi.mocked(useConnector).mockReturnValue(
+                connectorState({ id: 'solana:my-fork', label: 'Fork', url: 'https://rpc.example.com' }),
+            );
+
+            const { result } = renderHook(() => useKitTransactionSigner({ chain: 'solana:mainnet' }));
+
+            expect(result.current.signer).not.toBeNull();
+            expect(result.current.reason).toBeNull();
+        });
+
+        it('reports disconnected when no wallet is connected', () => {
+            vi.mocked(useConnector).mockReturnValue(
+                connectorState({ id: 'solana:devnet', label: 'Devnet', url: 'https://api.devnet.solana.com' }, {
+                    connected: false,
+                    selectedWallet: null,
+                    accounts: [],
+                    selectedAccount: null,
+                }),
+            );
+
+            const { result } = renderHook(() => useKitTransactionSigner());
+
+            expect(result.current.signer).toBeNull();
+            expect(result.current.reason).toBe('disconnected');
+        });
     });
 
     describe('useGillTransactionSigner (deprecated alias)', () => {

--- a/packages/connector/src/hooks/use-kit-transaction-signer.ts
+++ b/packages/connector/src/hooks/use-kit-transaction-signer.ts
@@ -12,8 +12,22 @@ import type { TransactionModifyingSigner } from '@solana/signers';
 import { createTransactionSignerFromWalletAccount } from '@solana/wallet-account-signer';
 import { getOrCreateUiWalletAccountForStandardWalletAccount } from '@wallet-standard/ui-registry';
 import { useConnector } from '../ui/connector-provider';
-import { toStandardWalletChain } from '../lib/wallet/kit-wallet-core';
+import { getStandardWalletChainForCluster } from '../utils/cluster';
 import { getUnderlyingWallet } from '../lib/wallet/wallet-icon-overrides';
+
+/**
+ * Options for useKitTransactionSigner
+ */
+export interface UseKitTransactionSignerOptions {
+    /**
+     * Explicit wallet chain to build the signer for, overriding the chain
+     * derived from the active cluster. The escape hatch for custom clusters
+     * (whose chain cannot be derived): pass the standard chain the custom
+     * endpoint actually serves, e.g. `'solana:mainnet'` for a private
+     * mainnet RPC.
+     */
+    chain?: `solana:${string}`;
+}
 
 /**
  * Return value from useKitTransactionSigner hook
@@ -30,6 +44,14 @@ export interface UseKitTransactionSignerReturn {
      * Useful for disabling transaction buttons
      */
     ready: boolean;
+
+    /**
+     * Why no signer is available, for diagnostics (null when ready).
+     * `'unsupported-chain'` means the active cluster is custom and no
+     * explicit `chain` override was given; `'signer-unavailable'` means the
+     * connected account does not support signing on the resolved chain.
+     */
+    reason: 'disconnected' | 'unsupported-chain' | 'signer-unavailable' | null;
 }
 
 /**
@@ -71,23 +93,26 @@ export type UseGillTransactionSignerReturn = UseKitTransactionSignerReturn;
  * }
  * ```
  */
-export function useKitTransactionSigner(): UseKitTransactionSignerReturn {
+export function useKitTransactionSigner(options?: UseKitTransactionSignerOptions): UseKitTransactionSignerReturn {
     const { selectedWallet, selectedAccount, accounts, cluster, connected } = useConnector();
+    const chainOverride = options?.chain;
 
     const account = useMemo(
         () => accounts.find(a => a.address === selectedAccount)?.raw ?? null,
         [accounts, selectedAccount],
     );
 
-    const signer = useMemo(() => {
+    const { signer, reason } = useMemo((): Pick<UseKitTransactionSignerReturn, 'signer' | 'reason'> => {
         if (!connected || !selectedWallet || !account || !cluster) {
-            return null;
+            return { signer: null, reason: 'disconnected' };
         }
 
-        // No wallet advertises a custom cluster id, and signing on the wrong
-        // chain would prompt against the wrong network.
-        const chain = toStandardWalletChain(cluster.id);
-        if (!chain) return null;
+        // Derive the chain from the cluster (not its raw id), so aliases like
+        // solana:mainnet-beta resolve. Custom clusters have no derivable
+        // chain, and signing on a substituted one would prompt against the
+        // wrong network — callers pass an explicit `chain` instead.
+        const chain = chainOverride ?? getStandardWalletChainForCluster(cluster);
+        if (!chain) return { signer: null, reason: 'unsupported-chain' };
 
         // The signer factory validates the chain and the account's signing
         // features at construction and throws when either is unsupported
@@ -98,15 +123,16 @@ export function useKitTransactionSigner(): UseKitTransactionSignerReturn {
                 getUnderlyingWallet(selectedWallet),
                 account,
             );
-            return createTransactionSignerFromWalletAccount(uiWalletAccount, chain);
+            return { signer: createTransactionSignerFromWalletAccount(uiWalletAccount, chain), reason: null };
         } catch {
-            return null;
+            return { signer: null, reason: 'signer-unavailable' };
         }
-    }, [connected, selectedWallet, account, cluster]);
+    }, [connected, selectedWallet, account, cluster, chainOverride]);
 
     return {
         signer,
         ready: Boolean(signer),
+        reason,
     };
 }
 

--- a/packages/connector/src/hooks/use-tokens.ts
+++ b/packages/connector/src/hooks/use-tokens.ts
@@ -573,7 +573,7 @@ function sortByValueDesc(a: Token, b: Token): number {
  * - Automatic request deduplication across components
  * - Shared data with useBalance (single RPC query)
  * - Token-2022 support
- * - Live updates via account subscription (with polling fallback)
+ * - Live updates via account subscription, with interval polling always running alongside
  * - Configurable auto-refresh behavior
  * - Abort support for in-flight requests
  * - Optional client override

--- a/packages/connector/src/hooks/use-transaction-preparer.ts
+++ b/packages/connector/src/hooks/use-transaction-preparer.ts
@@ -45,6 +45,14 @@ export interface TransactionPrepareOptions {
      * @default true
      */
     blockhashReset?: boolean;
+
+    /**
+     * Estimate and set compute/resource limits via simulation. Set to false
+     * for blockhash-only preparation of transactions that cannot simulate yet
+     * (e.g. an unfunded fee payer during onboarding).
+     * @default true
+     */
+    estimateResources?: boolean;
 }
 
 /**
@@ -169,6 +177,15 @@ export function useTransactionPreparer(): UseTransactionPreparerReturn {
         ): Promise<TMessage & TransactionMessageWithBlockhashLifetime> => {
             if (!client) {
                 throw new NetworkError('RPC_ERROR', 'Solana client not available. Cannot prepare transaction.');
+            }
+
+            if (options.estimateResources === false) {
+                return prepareTransaction({
+                    transaction,
+                    rpc: client.rpc,
+                    blockhashReset: options.blockhashReset,
+                    estimateResources: false,
+                });
             }
 
             return prepareTransaction({

--- a/packages/connector/src/lib/core/connector-client.test.ts
+++ b/packages/connector/src/lib/core/connector-client.test.ts
@@ -168,6 +168,21 @@ describe('ConnectorClient', () => {
         });
     });
 
+    describe('cluster switching', () => {
+        it('setCluster resolves without awaiting the wallet chain swap', async () => {
+            const { KitWalletCore } = await import('../wallet/kit-wallet-core');
+            const kitCore = vi.mocked(KitWalletCore).mock.results[0].value as {
+                setChain: ReturnType<typeof vi.fn>;
+            };
+            // A wallet that never answers its silent reconnect must not hang
+            // the cluster switch.
+            kitCore.setChain.mockReturnValue(new Promise(() => {}));
+
+            await expect(client.setCluster('solana:devnet')).resolves.toBeUndefined();
+            expect(kitCore.setChain).toHaveBeenCalled();
+        });
+    });
+
     describe('event system', () => {
         it('should register event listeners', () => {
             const listener = vi.fn();

--- a/packages/connector/src/lib/core/connector-client.test.ts
+++ b/packages/connector/src/lib/core/connector-client.test.ts
@@ -5,9 +5,12 @@ import type { ConnectorState } from '../../types/connector';
 import type { StateManager } from './state-manager';
 import type { SolanaCluster } from '@wallet-ui/core';
 
+const registerWalletConnectWallet = vi.hoisted(() => vi.fn());
+
 // Mock all dependencies
 vi.mock('./event-emitter');
 vi.mock('../wallet/kit-wallet-core');
+vi.mock('../wallet/walletconnect', () => ({ registerWalletConnectWallet }));
 vi.mock('../cluster/cluster-manager');
 vi.mock('../health/health-monitor');
 vi.mock('../transaction/transaction-tracker');
@@ -220,6 +223,39 @@ describe('ConnectorClient', () => {
 
             expect(kitCore.destroy).toHaveBeenCalledTimes(1);
             expect(kitCore.start).toHaveBeenCalledTimes(2);
+        });
+
+        it('discards a WalletConnect registration that resolves after destroy and re-init', async () => {
+            const resolvers: Array<(registration: { unregister: ReturnType<typeof vi.fn> }) => void> = [];
+            registerWalletConnectWallet.mockImplementation(() => new Promise(resolve => resolvers.push(resolve)));
+
+            const wcClient = new ConnectorClient({ walletConnect: { enabled: true, projectId: 'test' } });
+            await vi.waitFor(() => expect(registerWalletConnectWallet).toHaveBeenCalledTimes(1));
+
+            // Destroy while the first registration is still in flight, then
+            // re-initialize (StrictMode remount) — starting a second one.
+            wcClient.destroy();
+            (wcClient as unknown as { initialize: () => void }).initialize();
+            await vi.waitFor(() => expect(registerWalletConnectWallet).toHaveBeenCalledTimes(2));
+
+            // The stale first registration must be unregistered, not tracked.
+            const stale = { unregister: vi.fn() };
+            resolvers[0](stale);
+            await vi.waitFor(() => expect(stale.unregister).toHaveBeenCalledTimes(1));
+
+            // The current lifecycle's registration is tracked and cleaned up
+            // by the next destroy.
+            const current = { unregister: vi.fn() };
+            resolvers[1](current);
+            await vi.waitFor(() =>
+                expect((wcClient as unknown as { walletConnectRegistration: unknown }).walletConnectRegistration).toBe(
+                    current,
+                ),
+            );
+            expect(current.unregister).not.toHaveBeenCalled();
+
+            wcClient.destroy();
+            expect(current.unregister).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/connector/src/lib/core/connector-client.test.ts
+++ b/packages/connector/src/lib/core/connector-client.test.ts
@@ -76,6 +76,7 @@ describe('ConnectorClient', () => {
         vi.mocked(ClusterManager).mockImplementation(function () {
             return {
                 setCluster: vi.fn(),
+                getCluster: vi.fn(() => null),
                 getCurrentCluster: vi.fn(() => null),
                 getServerCluster: vi.fn(() => undefined),
             } as unknown as InstanceType<typeof ClusterManager>;
@@ -187,6 +188,23 @@ describe('ConnectorClient', () => {
     describe('cleanup', () => {
         it('should have destroy method for cleanup', () => {
             expect(typeof client.destroy).toBe('function');
+        });
+
+        it('re-initializes the wallet core after destroy (StrictMode remount)', async () => {
+            const { KitWalletCore } = await import('../wallet/kit-wallet-core');
+            const kitCore = vi.mocked(KitWalletCore).mock.results[0].value as {
+                start: ReturnType<typeof vi.fn>;
+                destroy: ReturnType<typeof vi.fn>;
+            };
+            expect(kitCore.start).toHaveBeenCalledTimes(1);
+
+            // StrictMode runs mount → cleanup (destroy) → mount (initialize)
+            // against the same ref-held client instance.
+            client.destroy();
+            (client as unknown as { initialize: () => void }).initialize();
+
+            expect(kitCore.destroy).toHaveBeenCalledTimes(1);
+            expect(kitCore.start).toHaveBeenCalledTimes(2);
         });
     });
 });

--- a/packages/connector/src/lib/core/connector-client.ts
+++ b/packages/connector/src/lib/core/connector-client.ts
@@ -142,7 +142,15 @@ export class ConnectorClient {
         try {
             // Dynamically import to avoid bundling WalletConnect if not used
             const { registerWalletConnectWallet } = await import('../wallet/walletconnect');
-            this.walletConnectRegistration = await registerWalletConnectWallet(this.config.walletConnect);
+            const registration = await registerWalletConnectWallet(this.config.walletConnect);
+
+            // destroy() may have run while the import was in flight; a
+            // registration completing now would outlive the client and leak.
+            if (!this.initialized) {
+                registration.unregister();
+                return;
+            }
+            this.walletConnectRegistration = registration;
 
             if (this.config.debug) {
                 logger.info('WalletConnect wallet registered successfully');
@@ -373,5 +381,10 @@ export class ConnectorClient {
         this.kitWalletCore.destroy();
         this.eventEmitter.offAll();
         this.stateManager.clear();
+
+        // The provider reuses this instance across an unmount/remount cycle
+        // (React StrictMode runs one on every dev mount) and re-runs
+        // initialize(), which must not early-return against a torn-down core.
+        this.initialized = false;
     }
 }

--- a/packages/connector/src/lib/core/connector-client.ts
+++ b/packages/connector/src/lib/core/connector-client.ts
@@ -36,6 +36,14 @@ export class ConnectorClient {
     private debugMetrics: DebugMetrics;
     private healthMonitor: HealthMonitor;
     private initialized = false;
+    /**
+     * Bumped by every destroy(). Async initialization work (the WalletConnect
+     * dynamic import + registration) captures the epoch it started under and
+     * discards its result when a destroy intervened — checking `initialized`
+     * alone is not enough, because a re-initialize sets it back to true and
+     * would let a previous lifecycle's registration attach untracked.
+     */
+    private lifecycleEpoch = 0;
     private serverSnapshot: ConnectorState;
     private config: ConnectorConfig;
     private walletConnectRegistration: WalletConnectRegistration | null = null;
@@ -138,15 +146,18 @@ export class ConnectorClient {
      */
     private async initializeWalletConnect(): Promise<void> {
         if (!this.config.walletConnect?.enabled) return;
+        const epoch = this.lifecycleEpoch;
 
         try {
             // Dynamically import to avoid bundling WalletConnect if not used
             const { registerWalletConnectWallet } = await import('../wallet/walletconnect');
             const registration = await registerWalletConnectWallet(this.config.walletConnect);
 
-            // destroy() may have run while the import was in flight; a
-            // registration completing now would outlive the client and leak.
-            if (!this.initialized) {
+            // A destroy() (and possibly a re-initialize, which starts its own
+            // registration) ran while the import was in flight; a registration
+            // from a previous lifecycle must not be tracked — an untracked
+            // registry entry can never be unregistered.
+            if (epoch !== this.lifecycleEpoch || !this.initialized) {
                 registration.unregister();
                 return;
             }
@@ -377,6 +388,8 @@ export class ConnectorClient {
     }
 
     destroy(): void {
+        this.lifecycleEpoch++;
+
         // Unregister WalletConnect wallet if it was registered
         if (this.walletConnectRegistration) {
             try {

--- a/packages/connector/src/lib/core/connector-client.ts
+++ b/packages/connector/src/lib/core/connector-client.ts
@@ -217,7 +217,18 @@ export class ConnectorClient {
 
     async setCluster(clusterId: SolanaClusterId): Promise<void> {
         await this.clusterManager.setCluster(clusterId);
-        await this.kitWalletCore.setChain(normalizeWalletChain(this.clusterManager.getCluster()?.id));
+        // The replacement wallet client's warm-up silently reconnects through
+        // the wallet extension, which can take arbitrarily long (the plugin
+        // puts no timeout on it), so the cluster switch must not wait on it.
+        // KitWalletCore's swap counter discards warm-ups a newer switch or a
+        // destroy() has made stale.
+        void this.kitWalletCore
+            .setChain(normalizeWalletChain(this.clusterManager.getCluster()?.id))
+            .catch((error: unknown) => {
+                if (this.config.debug) {
+                    logger.error('Wallet chain swap failed', { error });
+                }
+            });
     }
 
     getCluster(): SolanaCluster | null {

--- a/packages/connector/src/lib/core/connector-client.ts
+++ b/packages/connector/src/lib/core/connector-client.ts
@@ -172,7 +172,7 @@ export class ConnectorClient {
      * This is the recommended way to connect in vNext.
      *
      * @param connectorId - Stable connector identifier
-     * @param options - Connection options (silent mode, preferred account, etc.)
+     * @param options - Connection options (preferred account)
      */
     async connectWallet(connectorId: WalletConnectorId, options?: ConnectOptions): Promise<void> {
         await this.kitWalletCore.connectWallet(connectorId, options);

--- a/packages/connector/src/lib/kit/client.ts
+++ b/packages/connector/src/lib/kit/client.ts
@@ -62,8 +62,11 @@ export interface SolanaClient<TClusterUrl extends ModifiedClusterUrl | string = 
 
 /**
  * Resolve a URL or cluster moniker to a validated HTTP(S) RPC URL.
+ *
+ * Exported for internal use (the shared-client cache keys by resolved URL so
+ * a moniker and its full URL share one client); not part of the public API.
  */
-function resolveRpcUrl(urlOrMoniker: SolanaClientUrlOrMoniker, port?: number): URL {
+export function resolveRpcUrl(urlOrMoniker: SolanaClientUrlOrMoniker, port?: number): URL {
     let parsedUrl: URL;
 
     if (urlOrMoniker instanceof URL) {

--- a/packages/connector/src/lib/kit/index.ts
+++ b/packages/connector/src/lib/kit/index.ts
@@ -49,7 +49,11 @@ export {
 export { debug, isDebugEnabled, type LogLevel } from './debug';
 
 // Transaction preparation
-export { prepareTransaction, type PrepareTransactionConfig } from './prepare-transaction';
+export {
+    prepareTransaction,
+    type PrepareTransactionConfig,
+    type PrepareTransactionConfigWithoutEstimation,
+} from './prepare-transaction';
 
 // ============================================================================
 // Signer Types (from kit-signers)

--- a/packages/connector/src/lib/kit/prepare-transaction.test.ts
+++ b/packages/connector/src/lib/kit/prepare-transaction.test.ts
@@ -95,6 +95,55 @@ describe('prepareTransaction', () => {
         expect(getTransactionMessageComputeUnitLimit(prepared)).toBe(5497);
     });
 
+    it('skips simulation entirely with estimateResources: false', async () => {
+        // Typed without SimulateTransactionApi: also the compile-time proof
+        // that the narrower rpc is accepted when estimation is skipped.
+        const blockhashSend = vi.fn().mockResolvedValue({
+            value: { blockhash: BLOCKHASH, lastValidBlockHeight: 100n },
+        });
+        const mocks = { getLatestBlockhash: vi.fn(() => ({ send: blockhashSend })) };
+        const rpc = mocks as unknown as Rpc<GetLatestBlockhashApi>;
+
+        const prepared = await prepareTransaction({
+            transaction: createBaseMessage(),
+            rpc,
+            estimateResources: false,
+        });
+
+        expect(mocks.getLatestBlockhash).toHaveBeenCalledTimes(1);
+        expect(getTransactionMessageComputeUnitLimit(prepared)).toBeUndefined();
+        expect(prepared.lifetimeConstraint.blockhash).toBe(BLOCKHASH);
+    });
+
+    it('preserves an explicit compute unit limit with estimateResources: false', async () => {
+        const { rpc, mocks } = createMockRpc();
+        const transaction = setTransactionMessageComputeUnitLimit(200_000, createBaseMessage());
+
+        const prepared = await prepareTransaction({ transaction, rpc, estimateResources: false });
+
+        expect(mocks.simulateTransaction).not.toHaveBeenCalled();
+        expect(getTransactionMessageComputeUnitLimit(prepared)).toBe(200_000);
+    });
+
+    it('makes no RPC calls with estimateResources: false and a preset lifetime', async () => {
+        const { rpc, mocks } = createMockRpc();
+        const withLifetime = {
+            ...createBaseMessage(),
+            lifetimeConstraint: { blockhash: BLOCKHASH, lastValidBlockHeight: 100n },
+        } as Parameters<typeof prepareTransaction>[0]['transaction'];
+
+        const prepared = await prepareTransaction({
+            transaction: withLifetime,
+            rpc,
+            estimateResources: false,
+            blockhashReset: false,
+        });
+
+        expect(mocks.simulateTransaction).not.toHaveBeenCalled();
+        expect(mocks.getLatestBlockhash).not.toHaveBeenCalled();
+        expect(prepared.lifetimeConstraint.blockhash).toBe(BLOCKHASH);
+    });
+
     it('propagates simulation failures instead of defaulting', async () => {
         const rpc = {
             getLatestBlockhash: vi.fn(() => ({

--- a/packages/connector/src/lib/kit/prepare-transaction.ts
+++ b/packages/connector/src/lib/kit/prepare-transaction.ts
@@ -89,6 +89,40 @@ export interface PrepareTransactionConfig<TMessage extends PrepareCompilableTran
      * @default true
      */
     blockhashReset?: boolean;
+    /**
+     * Estimate and set compute/resource limits via simulation.
+     * @default true
+     */
+    estimateResources?: true;
+}
+
+/**
+ * Configuration for preparing a transaction without simulation-based resource
+ * estimation: only the blockhash lifetime is managed. For transactions that
+ * cannot simulate at preparation time (e.g. an unfunded fee payer during
+ * onboarding, or an instruction depending on state a prior transaction has
+ * not landed yet).
+ */
+export interface PrepareTransactionConfigWithoutEstimation<TMessage extends PrepareCompilableTransactionMessage> {
+    /**
+     * Transaction to prepare for sending to the blockchain
+     */
+    transaction: TMessage;
+    /**
+     * RPC client capable of getting the latest blockhash. Simulation
+     * capability is not required when estimation is skipped.
+     */
+    rpc: Rpc<GetLatestBlockhashApi>;
+    /**
+     * Whether or not you wish to force reset the latest blockhash (if one is already set)
+     * @default true
+     */
+    blockhashReset?: boolean;
+    /**
+     * Skip simulation-based resource estimation entirely; compute unit limits
+     * are left exactly as the message carries them.
+     */
+    estimateResources: false;
 }
 
 /**
@@ -103,6 +137,11 @@ export interface PrepareTransactionConfig<TMessage extends PrepareCompilableTran
  * `computeUnitLimitReset` is set — except the provisory value 0 and the
  * 1,400,000 maximum, which kit treats as unset and re-estimates.
  *
+ * Pass `estimateResources: false` to skip simulation entirely (blockhash-only
+ * preparation); the `rpc` then only needs `GetLatestBlockhashApi`. Use this
+ * for transactions that cannot simulate at preparation time, e.g. an unfunded
+ * fee payer during onboarding.
+ *
  * @param config - Configuration for transaction preparation
  * @returns Prepared transaction with resource limits and blockhash lifetime set
  *
@@ -116,36 +155,49 @@ export interface PrepareTransactionConfig<TMessage extends PrepareCompilableTran
  */
 export async function prepareTransaction<TMessage extends PrepareCompilableTransactionMessage>(
     config: PrepareTransactionConfig<TMessage>,
+): Promise<TMessage & TransactionMessageWithBlockhashLifetime>;
+export async function prepareTransaction<TMessage extends PrepareCompilableTransactionMessage>(
+    config: PrepareTransactionConfigWithoutEstimation<TMessage>,
+): Promise<TMessage & TransactionMessageWithBlockhashLifetime>;
+export async function prepareTransaction<TMessage extends PrepareCompilableTransactionMessage>(
+    config: PrepareTransactionConfig<TMessage> | PrepareTransactionConfigWithoutEstimation<TMessage>,
 ): Promise<TMessage & TransactionMessageWithBlockhashLifetime> {
     // Set config defaults
     const blockhashReset = config.blockhashReset !== false;
-    const { computeUnitLimitMultiplier } = config;
-    const getComputeUnitLimit =
-        computeUnitLimitMultiplier === undefined
-            ? getDefaultComputeUnitLimitFromEstimate
-            : (estimate: number) => Math.ceil(estimate * computeUnitLimitMultiplier);
 
     let transaction = config.transaction as TMessage & Partial<TransactionMessageWithBlockhashLifetime>;
 
-    if (config.computeUnitLimitReset) {
-        if (isDebugEnabled()) {
-            debug('Force resetting the compute unit limit.', 'debug');
-        }
-        transaction = setTransactionMessageComputeUnitLimit(undefined, transaction);
-    }
+    if (config.estimateResources !== false) {
+        const { computeUnitLimitMultiplier } = config;
+        const getComputeUnitLimit =
+            computeUnitLimitMultiplier === undefined
+                ? getDefaultComputeUnitLimitFromEstimate
+                : (estimate: number) => Math.ceil(estimate * computeUnitLimitMultiplier);
 
-    const estimateResourceLimits = estimateResourceLimitsFactory({ rpc: config.rpc });
-    const estimateAndSetResourceLimits = estimateAndSetResourceLimitsFactory(async (transactionMessage, config_) => {
-        const estimate = await estimateResourceLimits(transactionMessage, config_);
-        return {
-            ...estimate,
-            computeUnitLimit: Math.min(
-                Math.ceil(getComputeUnitLimit(estimate.computeUnitLimit)),
-                MAX_COMPUTE_UNIT_LIMIT,
-            ),
-        };
-    });
-    transaction = await estimateAndSetResourceLimits(transaction);
+        if (config.computeUnitLimitReset) {
+            if (isDebugEnabled()) {
+                debug('Force resetting the compute unit limit.', 'debug');
+            }
+            transaction = setTransactionMessageComputeUnitLimit(undefined, transaction);
+        }
+
+        const estimateResourceLimits = estimateResourceLimitsFactory({ rpc: config.rpc });
+        const estimateAndSetResourceLimits = estimateAndSetResourceLimitsFactory(
+            async (transactionMessage, config_) => {
+                const estimate = await estimateResourceLimits(transactionMessage, config_);
+                return {
+                    ...estimate,
+                    computeUnitLimit: Math.min(
+                        Math.ceil(getComputeUnitLimit(estimate.computeUnitLimit)),
+                        MAX_COMPUTE_UNIT_LIMIT,
+                    ),
+                };
+            },
+        );
+        transaction = await estimateAndSetResourceLimits(transaction);
+    } else if (isDebugEnabled()) {
+        debug('Skipping resource estimation (estimateResources: false).', 'debug');
+    }
 
     // Update the latest blockhash
     const hasLifetimeConstraint = 'lifetimeConstraint' in transaction;

--- a/packages/connector/src/lib/kit/signer-integration.test.ts
+++ b/packages/connector/src/lib/kit/signer-integration.test.ts
@@ -130,6 +130,25 @@ describe('createKitSignersFromWallet', () => {
             });
         });
 
+        it('logs only the endpoint origin, never credentials in userinfo, path, or query', () => {
+            const { account, wallet } = signingAccountAndWallet(['solana:devnet']);
+            warnSpy.mockClear();
+
+            createKitSignersFromWallet(
+                wallet,
+                account,
+                mockConnection('https://user:secret@rpc.example.com/v2/apikey123?api-key=xyz'),
+            );
+
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            const context = warnSpy.mock.calls[0][1] as { rpcEndpoint: string };
+            expect(context.rpcEndpoint).toBe('https://rpc.example.com');
+            const logged = JSON.stringify(warnSpy.mock.calls[0]);
+            expect(logged).not.toContain('secret');
+            expect(logged).not.toContain('apikey123');
+            expect(logged).not.toContain('api-key=xyz');
+        });
+
         it('treats an unparseable endpoint the same as an unrecognized one', () => {
             const { account, wallet } = signingAccountAndWallet(['solana:devnet']);
             warnSpy.mockClear();

--- a/packages/connector/src/lib/kit/signer-integration.test.ts
+++ b/packages/connector/src/lib/kit/signer-integration.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { Connection } from '@solana/web3.js';
 import { createKitSignersFromWallet } from './signer-integration';
-import { ConfigurationError } from '../errors';
 import { createMockPhantomWallet } from '../../__tests__/mocks/wallet-standard-mock';
 import { createMockWalletAccount, TEST_ADDRESSES } from '../../__tests__/fixtures/accounts';
+
+const warnSpy = vi.hoisted(() => vi.fn());
+vi.mock('../utils/secure-logger', () => ({
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: warnSpy, error: vi.fn() }),
+}));
 
 function mockConnection(rpcEndpoint: string): Connection {
     return { rpcEndpoint } as Connection;
@@ -111,28 +115,30 @@ describe('createKitSignersFromWallet', () => {
             expect(result.transactionSigner).not.toBeNull();
         });
 
-        it('does not fall back to devnet for an unrecognized endpoint', () => {
+        it('omits the transaction signer (without throwing or defaulting to devnet) for an unrecognized endpoint', () => {
             const { account, wallet } = signingAccountAndWallet(['solana:devnet']);
+            warnSpy.mockClear();
 
-            expect(() =>
-                createKitSignersFromWallet(wallet, account, mockConnection('https://rpc.example.com')),
-            ).toThrow(ConfigurationError);
-            expect(() =>
-                createKitSignersFromWallet(wallet, account, mockConnection('https://rpc.example.com')),
-            ).toThrow(/Cannot determine the Solana chain/);
+            const result = createKitSignersFromWallet(wallet, account, mockConnection('https://rpc.example.com'));
+
+            expect(result.address).toBe(TEST_ADDRESSES.ACCOUNT_1);
+            expect(result.messageSigner).not.toBeNull();
+            expect(result.transactionSigner).toBeNull();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Cannot determine the Solana chain'), {
+                rpcEndpoint: 'https://rpc.example.com',
+            });
         });
 
-        it('throws with the INVALID_CLUSTER code and the endpoint in context', () => {
+        it('treats an unparseable endpoint the same as an unrecognized one', () => {
             const { account, wallet } = signingAccountAndWallet(['solana:devnet']);
+            warnSpy.mockClear();
 
-            try {
-                createKitSignersFromWallet(wallet, account, mockConnection('not a url'));
-                expect.unreachable('expected a ConfigurationError');
-            } catch (error) {
-                expect(error).toBeInstanceOf(ConfigurationError);
-                expect((error as ConfigurationError).code).toBe('INVALID_CLUSTER');
-                expect((error as ConfigurationError).context).toEqual({ rpcEndpoint: 'not a url' });
-            }
+            const result = createKitSignersFromWallet(wallet, account, mockConnection('not a url'));
+
+            expect(result.messageSigner).not.toBeNull();
+            expect(result.transactionSigner).toBeNull();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
         });
 
         it('omits the transaction signer when neither a network nor a connection is given', () => {

--- a/packages/connector/src/lib/kit/signer-integration.ts
+++ b/packages/connector/src/lib/kit/signer-integration.ts
@@ -52,6 +52,19 @@ function chainFromRpcEndpoint(rpcUrl: string): `solana:${string}` | null {
 }
 
 /**
+ * Origin-only rendering of an endpoint for log output. Custom RPC URLs
+ * routinely carry credentials in the userinfo, the path (`/v2/<api-key>`),
+ * or the query string — none of which may reach logs.
+ */
+function describeEndpointForLog(rpcUrl: string): string {
+    try {
+        return new URL(rpcUrl).origin;
+    } catch {
+        return '<unparseable endpoint>';
+    }
+}
+
+/**
  * Create Kit-compatible signers from a Wallet Standard wallet
  *
  * Bridges a Wallet Standard wallet to modern Kit signers using
@@ -130,7 +143,7 @@ export function createKitSignersFromWallet(
             logger.warn(
                 'Cannot determine the Solana chain from the RPC endpoint; no transaction signer will be created. ' +
                     'Pass an explicit network to createKitSignersFromWallet.',
-                { rpcEndpoint: rpcUrl },
+                { rpcEndpoint: describeEndpointForLog(rpcUrl) },
             );
         }
     }

--- a/packages/connector/src/lib/kit/signer-integration.ts
+++ b/packages/connector/src/lib/kit/signer-integration.ts
@@ -15,7 +15,10 @@ import {
     createTransactionSendingSignerFromWalletAccount,
 } from '@solana/wallet-account-signer';
 import { getOrCreateUiWalletAccountForStandardWalletAccount } from '@wallet-standard/ui-registry';
-import { ConfigurationError } from '../errors';
+import { getClusterTypeFromRpcEndpoint } from '../../utils/rpc-endpoint';
+import { createLogger } from '../utils/secure-logger';
+
+const logger = createLogger('createKitSignersFromWallet');
 
 /**
  * Result of creating Kit signers from a Wallet Standard wallet
@@ -39,25 +42,13 @@ export interface KitSignersFromWallet {
  */
 export type KitSignerNetwork = 'mainnet' | 'devnet' | 'testnet' | 'localnet' | `solana:${string}`;
 
-const LOCAL_RPC_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0', '[::1]'];
-
 /**
  * Map an RPC endpoint to a Wallet Standard chain identifier, or null when the
  * endpoint does not identify a cluster.
  */
 function chainFromRpcEndpoint(rpcUrl: string): `solana:${string}` | null {
-    if (rpcUrl.includes('mainnet')) return 'solana:mainnet';
-    if (rpcUrl.includes('testnet')) return 'solana:testnet';
-    if (rpcUrl.includes('devnet')) return 'solana:devnet';
-
-    let host: string;
-    try {
-        host = new URL(rpcUrl).hostname.toLowerCase();
-    } catch {
-        return null;
-    }
-
-    return LOCAL_RPC_HOSTS.includes(host) ? 'solana:localnet' : null;
+    const type = getClusterTypeFromRpcEndpoint(rpcUrl);
+    return type === 'custom' ? null : `solana:${type}`;
 }
 
 /**
@@ -74,20 +65,19 @@ function chainFromRpcEndpoint(rpcUrl: string): `solana:${string}` | null {
  * 2. Otherwise, a `connection` endpoint is matched against the well-known
  *    clusters (a `mainnet`/`testnet`/`devnet` substring) and local hosts
  *    (`localhost`, `127.0.0.1`, `0.0.0.0`, `[::1]` map to `solana:localnet`).
- *    An endpoint that matches nothing throws: signing against a guessed chain
- *    makes a wallet prompt and simulate on a different network than the dapp
- *    is using.
- * 3. With neither an explicit network nor a connection the chain is unknown,
- *    so no transaction signer is returned. Message signing is not chain-scoped
- *    and is still available.
+ *    An endpoint that matches nothing (a custom RPC domain) leaves the chain
+ *    unknown and falls through to rule 3, with a warning telling the caller to
+ *    pass an explicit `network`. Guessing a chain would be worse: signing
+ *    against the wrong one makes a wallet prompt and simulate on a different
+ *    network than the dapp is using.
+ * 3. With an unknown chain no transaction signer is returned. Message signing
+ *    is not chain-scoped and is still available.
  *
  * @param wallet - The Wallet Standard wallet instance
  * @param account - The wallet account to use
  * @param connection - Optional connection whose RPC endpoint identifies the chain
  * @param network - Optional explicit network or `solana:*` chain identifier
  * @returns Kit signers object with address and signer instances
- * @throws {ConfigurationError} `INVALID_CLUSTER` when a connection is supplied
- * whose RPC endpoint does not identify a known cluster
  *
  * @example
  * ```typescript
@@ -137,9 +127,9 @@ export function createKitSignersFromWallet(
         const rpcUrl = connection.rpcEndpoint || '';
         chain = chainFromRpcEndpoint(rpcUrl);
         if (!chain) {
-            throw new ConfigurationError(
-                'INVALID_CLUSTER',
-                `Cannot determine the Solana chain from RPC endpoint "${rpcUrl}". Pass an explicit network to createKitSignersFromWallet.`,
+            logger.warn(
+                'Cannot determine the Solana chain from the RPC endpoint; no transaction signer will be created. ' +
+                    'Pass an explicit network to createKitSignersFromWallet.',
                 { rpcEndpoint: rpcUrl },
             );
         }

--- a/packages/connector/src/lib/utils/secure-logger.ts
+++ b/packages/connector/src/lib/utils/secure-logger.ts
@@ -17,7 +17,10 @@
  * ```
  */
 
-import { isDebugEnabled, debug as connectorDebug } from '../kit';
+// Import the concrete module, not the ../kit barrel: modules inside lib/kit
+// (e.g. signer-integration) use this logger, and going through the barrel
+// would create an import cycle that breaks module initialization.
+import { isDebugEnabled, debug as connectorDebug } from '../kit/debug';
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 

--- a/packages/connector/src/lib/wallet/kit-wallet-core.test.ts
+++ b/packages/connector/src/lib/wallet/kit-wallet-core.test.ts
@@ -8,7 +8,11 @@ import { EventEmitter } from '../core/event-emitter';
 import { INITIAL_WALLET_STATUS, createConnectorId } from '../../types/session';
 import type { ConnectorState } from '../../types/connector';
 import type { ConnectorEvent } from '../../types/events';
-import { createMockPhantomWallet, createMockSolflareWallet } from '../../__tests__/mocks/wallet-standard-mock';
+import {
+    createMockPhantomWallet,
+    createMockSolflareWallet,
+    setMockWalletAccountsSilently,
+} from '../../__tests__/mocks/wallet-standard-mock';
 import { createMockWalletAccount, TEST_ADDRESSES } from '../../__tests__/fixtures/accounts';
 import { setupMockWindow, cleanupMockWindow } from '../../__tests__/mocks/window-mock';
 import { waitForCondition } from '../../__tests__/utils/test-helpers';
@@ -185,6 +189,37 @@ describe('KitWalletCore', () => {
         await expect(walletCore.selectAccount('abc')).rejects.toThrow('Invalid address format');
         await expect(walletCore.selectAccount(TEST_ADDRESSES.ACCOUNT_2)).rejects.toThrow(
             'Requested account not available',
+        );
+    });
+
+    it('re-authorizes to select an account the session has not exposed yet', async () => {
+        const account1 = createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1);
+        const account2 = createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_2);
+        const wallet = createMockPhantomWallet({ accounts: [account1] });
+        registerWallet(wallet);
+        const walletCore = createCore();
+
+        await walletCore.connectWallet(createConnectorId('Phantom'));
+
+        // The wallet authorizes a second account, but the change event has
+        // not reached the session yet.
+        setMockWalletAccountsSilently(wallet, [account1, account2]);
+
+        await walletCore.selectAccount(TEST_ADDRESSES.ACCOUNT_2);
+        expect(stateManager.getSnapshot().selectedAccount).toBe(TEST_ADDRESSES.ACCOUNT_2);
+    });
+
+    it('maps a failed re-authorization to a reconnect error', async () => {
+        const account = createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1);
+        const wallet = createMockPhantomWallet({ accounts: [account] });
+        registerWallet(wallet);
+        const walletCore = createCore();
+
+        await walletCore.connectWallet(createConnectorId('Phantom'));
+        vi.mocked(wallet.features['standard:connect'].connect).mockRejectedValueOnce(new Error('User rejected'));
+
+        await expect(walletCore.selectAccount(TEST_ADDRESSES.ACCOUNT_2)).rejects.toThrow(
+            'Failed to reconnect wallet for account selection',
         );
     });
 

--- a/packages/connector/src/lib/wallet/kit-wallet-core.test.ts
+++ b/packages/connector/src/lib/wallet/kit-wallet-core.test.ts
@@ -336,6 +336,39 @@ describe('KitWalletCore', () => {
         expect(listener).not.toHaveBeenCalled();
     });
 
+    it('does not fire session listeners after disconnect and a new connection', async () => {
+        registerWallet(createMockPhantomWallet({ accounts: [createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1)] }));
+        registerWallet(createMockSolflareWallet({ accounts: [createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_2)] }));
+        const walletCore = createCore();
+
+        await walletCore.connectWallet(createConnectorId('Phantom'));
+        const state = stateManager.getSnapshot();
+        if (state.wallet.status !== 'connected') throw new Error('expected connected');
+        const listener = vi.fn();
+        state.wallet.session.onAccountsChanged(listener);
+
+        await walletCore.disconnect();
+        await walletCore.connectWallet(createConnectorId('Solflare'));
+
+        expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('does not fire session listeners across a direct wallet switch', async () => {
+        registerWallet(createMockPhantomWallet({ accounts: [createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1)] }));
+        registerWallet(createMockSolflareWallet({ accounts: [createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_2)] }));
+        const walletCore = createCore();
+
+        await walletCore.connectWallet(createConnectorId('Phantom'));
+        const state = stateManager.getSnapshot();
+        if (state.wallet.status !== 'connected') throw new Error('expected connected');
+        const listener = vi.fn();
+        state.wallet.session.onAccountsChanged(listener);
+
+        await walletCore.connectWallet(createConnectorId('Solflare'));
+
+        expect(listener).not.toHaveBeenCalled();
+    });
+
     it('supports connecting again after destroy and restart', async () => {
         const account = createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1);
         registerWallet(createMockPhantomWallet({ accounts: [account] }));

--- a/packages/connector/src/lib/wallet/kit-wallet-core.test.ts
+++ b/packages/connector/src/lib/wallet/kit-wallet-core.test.ts
@@ -234,6 +234,68 @@ describe('KitWalletCore', () => {
         }
     });
 
+    it('does not wipe persistence when silent reconnect fails during setChain', async () => {
+        setupMockWindow();
+        try {
+            const account = createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1);
+            const wallet = createMockPhantomWallet({ accounts: [account] });
+            registerWallet(wallet);
+
+            let value: string | undefined;
+            const storage = {
+                get: vi.fn(() => value),
+                set: vi.fn((next: string | undefined) => {
+                    value = next;
+                }),
+                clear: vi.fn(),
+            };
+            const walletCore = createCore({ walletStorage: storage });
+
+            await walletCore.connectWallet(createConnectorId('Phantom'));
+            await waitForCondition(() => value === `Phantom:${TEST_ADDRESSES.ACCOUNT_1}`, { timeout: 2000 });
+
+            // The replacement client's silent reconnect is rejected (a wallet
+            // that refuses silent connects); a network switch must not turn
+            // that into a wiped persisted session.
+            vi.mocked(wallet.features['standard:connect'].connect).mockRejectedValue(new Error('silent rejected'));
+            await walletCore.setChain('solana:devnet');
+
+            expect(value).toBe(`Phantom:${TEST_ADDRESSES.ACCOUNT_1}`);
+            expect(storage.clear).not.toHaveBeenCalled();
+        } finally {
+            cleanupMockWindow();
+        }
+    });
+
+    it('clears persistence on explicit disconnect after a completed chain swap', async () => {
+        setupMockWindow();
+        try {
+            const account = createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1);
+            registerWallet(createMockPhantomWallet({ accounts: [account] }));
+
+            let value: string | undefined;
+            const storage = {
+                get: vi.fn(() => value),
+                set: vi.fn((next: string | undefined) => {
+                    value = next;
+                }),
+                clear: vi.fn(),
+            };
+            const walletCore = createCore({ walletStorage: storage });
+
+            await walletCore.connectWallet(createConnectorId('Phantom'));
+            await walletCore.setChain('solana:devnet');
+            await waitForCondition(() => stateManager.getSnapshot().wallet.status === 'connected', { timeout: 2000 });
+
+            // Suppression is scoped to the warm-up; a real disconnect on the
+            // attached client still clears storage.
+            await walletCore.disconnect();
+            await waitForCondition(() => storage.clear.mock.calls.length > 0, { timeout: 2000 });
+        } finally {
+            cleanupMockWindow();
+        }
+    });
+
     it('silently restores a persisted session with autoConnect', async () => {
         setupMockWindow();
         try {

--- a/packages/connector/src/lib/wallet/kit-wallet-core.test.ts
+++ b/packages/connector/src/lib/wallet/kit-wallet-core.test.ts
@@ -323,6 +323,31 @@ describe('KitWalletCore', () => {
         expect(storage.set).not.toHaveBeenCalledWith(undefined);
     });
 
+    it('preserves a legacy bare-name persisted value without reconnecting or clearing', async () => {
+        const account = createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1);
+        registerWallet(createMockPhantomWallet({ accounts: [account] }));
+
+        // Pre-plugin releases persisted just the wallet name.
+        let value: string | undefined = 'Phantom';
+        const storage = {
+            get: vi.fn(() => value),
+            set: vi.fn((next: string | undefined) => {
+                value = next;
+            }),
+            clear: vi.fn(),
+        };
+        const walletCore = createCore({ autoConnect: true, walletStorage: storage });
+
+        await waitForCondition(() => stateManager.getSnapshot().wallet.status === 'disconnected', { timeout: 2000 });
+        expect(value).toBe('Phantom');
+        expect(storage.clear).not.toHaveBeenCalled();
+        expect(storage.set).not.toHaveBeenCalledWith(undefined);
+
+        // The next manual connect upgrades the value to the plugin format.
+        await walletCore.connectWallet(createConnectorId('Phantom'));
+        await waitForCondition(() => value === `Phantom:${TEST_ADDRESSES.ACCOUNT_1}`, { timeout: 2000 });
+    });
+
     it('auto-reconnects from a consumer storage adapter', async () => {
         const account = createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1);
         registerWallet(createMockPhantomWallet({ accounts: [account] }));

--- a/packages/connector/src/lib/wallet/kit-wallet-core.test.ts
+++ b/packages/connector/src/lib/wallet/kit-wallet-core.test.ts
@@ -274,6 +274,19 @@ describe('KitWalletCore', () => {
         expect(listener).not.toHaveBeenCalled();
     });
 
+    it('supports connecting again after destroy and restart', async () => {
+        const account = createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1);
+        registerWallet(createMockPhantomWallet({ accounts: [account] }));
+        const walletCore = createCore();
+        await waitForCondition(() => stateManager.getSnapshot().connectors.length > 0, { timeout: 2000 });
+
+        walletCore.destroy();
+        walletCore.start('solana:mainnet');
+
+        await walletCore.connectWallet(createConnectorId('Phantom'));
+        expect(stateManager.getSnapshot().wallet.status).toBe('connected');
+    });
+
     it('persists the active connection through a consumer storage adapter', async () => {
         const account = createMockWalletAccount(TEST_ADDRESSES.ACCOUNT_1);
         registerWallet(createMockPhantomWallet({ accounts: [account] }));

--- a/packages/connector/src/lib/wallet/kit-wallet-core.ts
+++ b/packages/connector/src/lib/wallet/kit-wallet-core.ts
@@ -82,7 +82,10 @@ function normalizeWalletName(value: string): string {
  * interface the kit wallet plugin persists through. The adapter already owns
  * the key it writes under, so the key the plugin supplies is ignored.
  */
-function toKitWalletStorage(adapter: StorageAdapter<string | undefined>): KitWalletStorage {
+function toKitWalletStorage(
+    adapter: StorageAdapter<string | undefined>,
+    suppressRemove?: () => boolean,
+): KitWalletStorage {
     return {
         getItem: () => {
             const value = adapter.get() ?? null;
@@ -96,6 +99,7 @@ function toKitWalletStorage(adapter: StorageAdapter<string | undefined>): KitWal
             return value;
         },
         removeItem: () => {
+            if (suppressRemove?.()) return;
             const withClear = adapter as StorageAdapter<string | undefined> & { clear?: () => void };
             if (typeof withClear.clear === 'function') {
                 withClear.clear();
@@ -258,12 +262,25 @@ export class KitWalletCore {
         // reconnect it (via the plugin's own persistence) or the chain switch
         // would drop the user's wallet.
         const hasLiveSession = Boolean(this.client?.wallet.getState().connected);
-        const next = this.buildClient(chain, hasLiveSession || undefined);
+        let warming = true;
+        const next = this.buildClient(chain, {
+            autoConnect: hasLiveSession || undefined,
+            // A failed silent reconnect makes the plugin clear its persisted
+            // account. During a chain swap that would turn a mere network
+            // switch into a permanent logout, so the replacement client must
+            // not remove anything while it warms up. The old client (an
+            // explicit disconnect) and the attached client afterwards clear
+            // normally, and a genuinely revoked session is still cleared by
+            // the next startup reconnect at rest.
+            suppressRemove: () => warming,
+        });
         try {
             await next.wallet.whenReady();
         } catch (error) {
             // A disposed or failed warm-up still settles; proceed with the swap
             if (this.options.debug) logger.warn('Chain-swap warm-up failed', { chain, error });
+        } finally {
+            warming = false;
         }
 
         // The warm-up spans a destroy() or a newer switch, either of which
@@ -375,15 +392,18 @@ export class KitWalletCore {
     // Client lifecycle
     // ========================================================================
 
-    private buildClient(chain: string, autoConnect?: boolean): KitWalletClient {
+    private buildClient(
+        chain: string,
+        opts?: { autoConnect?: boolean; suppressRemove?: () => boolean },
+    ): KitWalletClient {
         const display = this.options.display;
         const walletStorage = this.options.walletStorage;
         return createClient().use(
             walletSigner({
-                autoConnect: autoConnect ?? this.options.autoConnect ?? false,
+                autoConnect: opts?.autoConnect ?? this.options.autoConnect ?? false,
                 chain: chain as `${string}:${string}`,
                 filter: display ? wallet => applyWalletDisplayConfig([wallet], display).length > 0 : undefined,
-                storage: walletStorage ? toKitWalletStorage(walletStorage) : undefined,
+                storage: walletStorage ? toKitWalletStorage(walletStorage, opts?.suppressRemove) : undefined,
                 storageKey: KIT_WALLET_STORAGE_KEY,
             }),
         ) as unknown as KitWalletClient;

--- a/packages/connector/src/lib/wallet/kit-wallet-core.ts
+++ b/packages/connector/src/lib/wallet/kit-wallet-core.ts
@@ -267,6 +267,10 @@ export class KitWalletCore {
     }
 
     destroy(): void {
+        // Invalidate any in-flight setChain warm-up: after a later start() the
+        // staleness guard would otherwise pass (started is true again, counter
+        // unchanged) and attach a client built for the pre-destroy chain.
+        this.chainSwap++;
         this.detachClient();
         this.unregisterAdditionalWallets?.();
         this.unregisterAdditionalWallets = null;

--- a/packages/connector/src/lib/wallet/kit-wallet-core.ts
+++ b/packages/connector/src/lib/wallet/kit-wallet-core.ts
@@ -371,6 +371,14 @@ export class KitWalletCore {
         this.sync();
     }
 
+    /**
+     * Select an account within the connected session. When the requested
+     * address is not among the accounts the wallet has exposed yet, connect is
+     * re-invoked to refresh the authorized set before giving up — the user may
+     * have just authorized the account in the wallet. Note the re-connect can
+     * itself move the plugin's active account even when the requested address
+     * never appears.
+     */
     async selectAccount(address: string): Promise<void> {
         const client = this.requireClient();
         const connected = client.wallet.getState().connected;
@@ -380,7 +388,21 @@ export class KitWalletCore {
         if (!address || address.length < 5) {
             throw new Error('Invalid address format');
         }
-        const uiAccount = connected.wallet.accounts.find(account => account.address === address);
+        let uiAccount = connected.wallet.accounts.find(account => account.address === address);
+        if (!uiAccount) {
+            // Keep projecting a connect attempt against the current wallet so
+            // the plugin's transient 'connecting' status does not flicker the
+            // UI to disconnected during the re-authorization.
+            this.connectingConnectorId = createConnectorId(connected.wallet.name);
+            try {
+                const refreshed = await client.wallet.connect(connected.wallet);
+                uiAccount = refreshed.find(account => account.address === address);
+            } catch {
+                throw new Error('Failed to reconnect wallet for account selection');
+            } finally {
+                this.connectingConnectorId = null;
+            }
+        }
         if (!uiAccount) {
             throw new Error('Requested account not available');
         }

--- a/packages/connector/src/lib/wallet/kit-wallet-core.ts
+++ b/packages/connector/src/lib/wallet/kit-wallet-core.ts
@@ -610,6 +610,7 @@ export class KitWalletCore {
             // Switching wallets ends the previous session; consumers that track
             // sessions off the event stream need to see it close.
             if (previous) {
+                this.endSessionListeners();
                 this.eventEmitter.emit({ type: 'wallet:disconnected', timestamp: timestamp() });
             }
             this.eventEmitter.emit({
@@ -625,10 +626,22 @@ export class KitWalletCore {
                 timestamp: timestamp(),
             });
         } else if (!next && previous) {
+            this.endSessionListeners();
             this.eventEmitter.emit({ type: 'wallet:disconnected', timestamp: timestamp() });
         }
 
         this.previousConnection = next;
+    }
+
+    /**
+     * `onAccountsChanged` subscriptions belong to the session that handed them
+     * out; dropping them when it ends keeps a dead session's listeners from
+     * firing with the next session's accounts. (Runs before the notify loop in
+     * `project`, so a wallet switch never dispatches to the old set.)
+     */
+    private endSessionListeners(): void {
+        this.accountsChangedListeners.clear();
+        this.lastNotifiedAccountsKey = null;
     }
 
     // ========================================================================

--- a/packages/connector/src/lib/wallet/kit-wallet-core.ts
+++ b/packages/connector/src/lib/wallet/kit-wallet-core.ts
@@ -84,7 +84,17 @@ function normalizeWalletName(value: string): string {
  */
 function toKitWalletStorage(adapter: StorageAdapter<string | undefined>): KitWalletStorage {
     return {
-        getItem: () => adapter.get() ?? null,
+        getItem: () => {
+            const value = adapter.get() ?? null;
+            // Pre-plugin versions persisted the bare wallet name under the
+            // same adapter. The plugin erases any value that does not parse as
+            // `<name>:<address>`, so hand it null instead: it settles
+            // disconnected without touching storage, the legacy value
+            // survives, and the next connect overwrites it in the new format.
+            // (An explicit disconnect still clears it via removeItem.)
+            if (value !== null && parsePersistedWalletName(value) === null) return null;
+            return value;
+        },
         removeItem: () => {
             const withClear = adapter as StorageAdapter<string | undefined> & { clear?: () => void };
             if (typeof withClear.clear === 'function') {

--- a/packages/connector/src/types/session.ts
+++ b/packages/connector/src/types/session.ts
@@ -127,16 +127,15 @@ export interface WalletConnector extends WalletConnectorMetadata {
  */
 export interface ConnectOptions {
     /**
-     * Attempt silent connection without user prompt.
-     * If the wallet has previously authorized this app, it may connect
-     * without showing a popup.
-     * @default false
+     * @deprecated No-op under the kit wallet plugin backend: its connect is
+     * always interactive. Silent session restore happens automatically via
+     * `autoConnect` persistence instead. Will be removed in the next major.
      */
     silent?: boolean;
 
     /**
-     * If silent connection fails, allow falling back to interactive connection.
-     * @default true (when silent is true)
+     * @deprecated No-op under the kit wallet plugin backend; see
+     * {@link ConnectOptions.silent}. Will be removed in the next major.
      */
     allowInteractiveFallback?: boolean;
 

--- a/packages/connector/src/utils/chain.ts
+++ b/packages/connector/src/utils/chain.ts
@@ -2,6 +2,7 @@ import type { SolanaCluster, SolanaClusterId } from '@wallet-ui/core';
 import type { Connection } from '@solana/web3.js';
 import type { ClusterType } from './cluster';
 import { getClusterType, isMainnetCluster, isDevnetCluster, isTestnetCluster } from './cluster';
+import { getClusterTypeFromRpcEndpoint } from './rpc-endpoint';
 
 export const SOLANA_CHAIN_IDS = {
     mainnet: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
@@ -97,25 +98,7 @@ export function getClusterTypeFromConnection(connection: Connection | null): Clu
         return null;
     }
 
-    const rpcUrl = connection.rpcEndpoint || '';
-
-    if (rpcUrl.includes('mainnet') || rpcUrl.includes('api.mainnet-beta')) {
-        return 'mainnet';
-    }
-
-    if (rpcUrl.includes('testnet')) {
-        return 'testnet';
-    }
-
-    if (rpcUrl.includes('devnet')) {
-        return 'devnet';
-    }
-
-    if (rpcUrl.includes('localhost') || rpcUrl.includes('127.0.0.1')) {
-        return 'localnet';
-    }
-
-    return 'custom';
+    return getClusterTypeFromRpcEndpoint(connection.rpcEndpoint || '');
 }
 
 export function getChainIdFromConnection(

--- a/packages/connector/src/utils/cluster.ts
+++ b/packages/connector/src/utils/cluster.ts
@@ -138,6 +138,19 @@ export function getClusterType(cluster: SolanaCluster): ClusterType {
     return 'custom';
 }
 
+/**
+ * The standard wallet chain (`solana:mainnet|devnet|testnet|localnet`) for a
+ * cluster, or null for custom clusters. Derives from the cluster rather than
+ * its raw id, so aliases like `solana:mainnet-beta` and URL-detected local
+ * clusters resolve correctly. Callers building signers must treat null as "no
+ * signer available" — signing against a substituted chain would prompt the
+ * wallet on a different network than the dapp is using.
+ */
+export function getStandardWalletChainForCluster(cluster: SolanaCluster): `solana:${string}` | null {
+    const type = getClusterType(cluster);
+    return type === 'custom' ? null : `solana:${type}`;
+}
+
 export function getClusterChainId(cluster: SolanaCluster): `solana:${string}` | null {
     const clusterType = getClusterType(cluster);
 

--- a/packages/connector/src/utils/rpc-endpoint.test.ts
+++ b/packages/connector/src/utils/rpc-endpoint.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { getClusterTypeFromRpcEndpoint } from './rpc-endpoint';
+
+describe('getClusterTypeFromRpcEndpoint', () => {
+    it.each([
+        ['https://api.mainnet-beta.solana.com', 'mainnet'],
+        ['https://mainnet.helius-rpc.com', 'mainnet'],
+        ['https://api.testnet.solana.com', 'testnet'],
+        ['https://api.devnet.solana.com', 'devnet'],
+        ['http://localhost:8899', 'localnet'],
+        ['http://127.0.0.1:8899', 'localnet'],
+        ['http://0.0.0.0:8899', 'localnet'],
+        ['http://[::1]:8899', 'localnet'],
+        ['https://rpc.example.com', 'custom'],
+        ['not a url', 'custom'],
+        ['', 'custom'],
+    ] as const)('classifies %s as %s', (endpoint, expected) => {
+        expect(getClusterTypeFromRpcEndpoint(endpoint)).toBe(expected);
+    });
+
+    it('falls back to substring matching for local endpoints that do not parse as URLs', () => {
+        expect(getClusterTypeFromRpcEndpoint('localhost:8899')).toBe('localnet');
+    });
+});

--- a/packages/connector/src/utils/rpc-endpoint.ts
+++ b/packages/connector/src/utils/rpc-endpoint.ts
@@ -1,0 +1,34 @@
+/**
+ * RPC endpoint classification
+ *
+ * Single source of truth for "which cluster is this endpoint" — shared by the
+ * `ClusterType`-vocabulary consumers (`utils/chain.ts`) and the wallet-chain
+ * consumers (`lib/kit/signer-integration.ts`), which map the result into
+ * their own vocabularies. Kept dependency-free (type-only imports) so it can
+ * be imported from anywhere without creating a cycle through the barrels.
+ */
+
+import type { ClusterType } from './cluster';
+
+const LOCAL_RPC_HOSTS = ['localhost', '127.0.0.1', '0.0.0.0', '[::1]'];
+
+/**
+ * Classify an RPC endpoint URL into a cluster type, or 'custom' when nothing
+ * matches. Well-known clusters match by substring; local endpoints match by
+ * hostname (with a substring fallback for strings that do not parse as URLs).
+ */
+export function getClusterTypeFromRpcEndpoint(rpcUrl: string): ClusterType {
+    if (rpcUrl.includes('mainnet')) return 'mainnet';
+    if (rpcUrl.includes('testnet')) return 'testnet';
+    if (rpcUrl.includes('devnet')) return 'devnet';
+
+    try {
+        const host = new URL(rpcUrl).hostname.toLowerCase();
+        if (LOCAL_RPC_HOSTS.includes(host)) return 'localnet';
+    } catch {
+        // Not a parseable URL; fall through to the substring check.
+    }
+    if (rpcUrl.includes('localhost') || rpcUrl.includes('127.0.0.1')) return 'localnet';
+
+    return 'custom';
+}


### PR DESCRIPTION
Stacked on #56. Fixes the 11 confirmed correctness bugs a multi-agent review found in the new kit-plugin glue layer (each finding was adversarially verified against the plugin's 0.18.0 dist before being fixed). One commit per fix.

## Lifecycle & persistence (`connector-client.ts`, `kit-wallet-core.ts`)

- **Re-initialize after destroy** (`7ad54bf`): `destroy()` never reset `initialized`, so React StrictMode's dev unmount/remount left the wallet client permanently torn down — every connect threw "Wallet client not initialized". Also invalidates in-flight chain-swap warm-ups across destroy→start and drops WalletConnect registrations that complete after destroy.
- **Legacy persistence preserved** (`6758ebc`): pre-plugin releases stored a bare wallet name; the plugin erased it and silently logged every upgrading user out once. The storage bridge now hands the plugin `null` for legacy values so they survive until the next connect rewrites them.
- **Cluster switches** (`d08d28d`): `setCluster` no longer awaits the replacement client's unbounded silent-reconnect warm-up, and a failed silent reconnect during the swap no longer wipes the persisted session (removeItem suppressed only while the replacement warms up).
- **Listener leak** (`e8560ea`): `onAccountsChanged` listeners are cleared at session end instead of firing with the next session's accounts.
- **selectAccount fallback** (`0fbf8e1`): restores the pre-plugin re-authorize-on-miss behavior via the plugin's own `connect`.
- **silent options deprecated** (`556961c`): `ConnectOptions.silent`/`allowInteractiveFallback` are no-ops under the plugin; marked `@deprecated`, docs rewritten around `autoConnect` restore (no runtime change, per scope decision).

## Hooks & public API

- **Stale token balances** (`66e5b8a`): polling no longer stops when the account subscription loads — the subscription only watches the system account, so SPL token changes went permanently stale ('loaded' is sticky across clean socket closes). Subscriptions now purely add push immediacy.
- **Duplicate WebSockets** (`37726df`): one shared `SolanaClient` per resolved RPC URL across hooks; kit's coalescing is per-transport, so per-hook clients each opened their own socket.
- **prepareTransaction opt-out** (`cbcafa9`): `estimateResources: false` selects a blockhash-only overload accepting plain `Rpc<GetLatestBlockhashApi>` — un-breaks minimal-rpc callers and unfunded-fee-payer flows that worked pre-rework.
- **createKitSignersFromWallet** (`73b9f3d`): warns and omits the transaction signer for unrecognized endpoints instead of throwing in render; deliberately does not restore the old silent-devnet default (wrong-network submissions). Also unifies the two divergent RPC-endpoint classifiers.
- **useKitTransactionSigner** (`caca912`): derives the chain from the cluster (fixes `solana:mainnet-beta` and URL-detected localnets), adds a `chain` override for custom clusters and a `reason` field.

## Test plan

- `pnpm build`, `pnpm type-check` green at repo root (CI commands)
- `pnpm --filter @solana/connector test`: 928 passed / 19 skipped (baseline on #56: 835/19; delta is the new regression tests plus the refreshed 0.18.0 install — note `node_modules` on the base branch was stale at plugin 0.13.1 vs the lockfile's 0.18.0)
- Connector prettier lint green
- ~40 new regression tests, one or more per fix

## Follow-ups (out of scope)

- True poll elimination for balances requires also subscribing to the wallet's token accounts.
- The notification-triggered refetch still includes a redundant `getBalance` leg (kept to preserve shared-query in-flight dedup).
- Quality-tier review findings (session identity churn per store emission, error classification by message substring, `kit.ts` star-exports, icon-override Proxy identity fork) intentionally left for separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)